### PR TITLE
Release 0.1.1

### DIFF
--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -2,6 +2,9 @@
 set -e
 exec 9>/tmp/idya-prod-deploy.lock
 flock 9
+# Webhook process loads its own .env (dotenv/config) which leaks DATABASE_URL
+# into spawned shells. Unset it so Prisma reads the repo's .env from disk.
+unset DATABASE_URL
 cd /home/mac-admin/Idya-prod
 git fetch origin main
 git reset --hard origin/main

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,9 @@
 set -e
 exec 9>/tmp/idya-dev-deploy.lock
 flock 9
+# Webhook process loads its own .env (dotenv/config) which leaks DATABASE_URL
+# into spawned shells. Unset it so Prisma reads the repo's .env from disk.
+unset DATABASE_URL
 cd /home/mac-admin/Idya
 git fetch origin dev
 git reset --hard origin/dev

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.1.1 — 2026-06-01
+
+Hunting moves into the web app, combat resolution gets a real per-phase
+death check, and a swarm of small UX + naming polish across the battle
+screen and shops.
+
+### Hunt → Web App
+- **Bait picker in the SPA** — `/hunt` now opens the hunt view inside the web app instead of running through Discord buttons; #forest channel gate preserved
+- **Battle screen on the new palette** — colors brought into line with the rest of `/app`; status bar, action panel, log, and combatant cards all use the shared CSS variables
+- **SPA layout header on battle page** — battle pages now show the same top header as the rest of the app, so navigation stays put when a fight starts
+- **"Return to Town"** — post-battle button now lands you back on the hunt view inside the app
+- **Profession train buttons moved** — out of the always-visible header and onto the Character page where they belong
+
+### Combat Resolution
+- **Sub-phase ordering: defend → attack → special** — actions now resolve in this fixed order within a round (this is what the tutorial has been teaching all along; previously they ran in submission order)
+- **Player before AI within each sub-phase** — player defends, then AI defends, with a death check between each action. An AI's Defend action is no longer wasted on the trigger turn
+- **Sequential DOT** — end-of-round damage-over-time ticks one combatant at a time (AI first), with a death check between every tick
+- **First-to-zero loses** — if both sides hit 0 in the same step, the side that hit 0 first loses. No player-default tie-break
+- **Battle ends on enemy KO** — a post-kill DOT can't cause a tie anymore; the round resolves as soon as one team is wiped
+
+### Combat UI
+- **Log line classification** — lines tagged as flavor / action-head / mechanics / move / status / crit and colored accordingly. Flavor text now reads as italic gold, mechanics as monospace muted
+- **Log filter chips** — Flavor / Actions / Mechanics / Moves toggles in the log header, with localStorage persistence
+- **Action category tags** — every action button now shows a `[defend]` / `[attack]` / `[special]` chip before the action name, so the rock-paper-scissors structure is visible at pick time
+- **Status badges on combatant cards** — block, shield, DOT, buff, debuff, reflect each render as a small badge with remaining rounds
+- **Own-tile target click fix** — clicking your own tile during target selection no longer bounces back to action select; self-targeting actions (Heal/Buff) can pick the player's tile
+
+### Naming Consistency
+- **Upgrade material names** — `/api/upgrade` now sends `material_name` alongside the id, so "Next: 3 Treated Sulwood" displays instead of `treated_sulwood`. "Need N material" error also uses the display name
+- **Craft ingredient names** — hybrid weapon ingredients (sword_talamite, axe_talamite, etc.) resolve to the YAML Name instead of leaking the raw key
+- **Shop toast bold** — buy/sell messages dropped the `**markdown bold**` since web toasts render asterisks literally
+
+### Fixes
+- **Weapon upgrades weren't applied in combat** — `createSession` rolled against the base weapon Field. Now applies the upgrade JSON (`base + player + enchants`) to the Weapon's actions before the session starts. Sebastian's Wand rolling 21 against a minimum 29 was the trigger
+- **Upgrade endpoint wiped enchants** — the upgrade write was clobbering the `enchants` sub-key. Now spreads existing upgrades and only overwrites `base` / `player`
+- **Shop stock display when full** — venison and other items couldn't be sold when shops hit max stock because the sell list hid quantity info. Stock now shows `XXX/YYY` and owned quantity stays visible even at cap
+- **Crafting page locked recipes invisible** — `--text-vdim` on the dark background made locked recipe text unreadable. Switched to `--text-faint`
+
+### Infrastructure
+- **Deploy scripts `unset DATABASE_URL`** — the webhook process inherits `DATABASE_URL` from its environment, which was leaking into spawned deploy shells and causing prod deploys to connect to the dev database. Both `deploy.sh` and `deploy-prod.sh` now unset it so Prisma reads the repo's `.env`
+
+---
+
 ## 0.1.0 — 2026-05-31
 
 First major post-demo iteration. Web app SPA, unique weapon instances,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "//3": "updating this file will download and update your packages",
   "name": "idya",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "RPG Bot",
   "author": "pg805",
   "main": "./src/discord/init.ts",

--- a/public/app.html
+++ b/public/app.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="/views/bench.css">
   <link rel="stylesheet" href="/views/professions.css">
   <link rel="stylesheet" href="/views/enemies.css">
+  <link rel="stylesheet" href="/views/hunt.css">
   <script>if (location.port === '3000') document.title += ' — Dev';</script>
 </head>
 <body>
@@ -23,6 +24,7 @@
       <div class="nav-group">
         <a class="nav-link" data-path="/character">Character</a>
         <a class="nav-link" data-path="/inventory">Inventory</a>
+        <a class="nav-link" data-path="/hunt">Hunt</a>
       </div>
       <div class="nav-group">
         <p class="nav-label">Bench</p>
@@ -59,6 +61,7 @@
   <script src="/views/enchant.js"></script>
   <script src="/views/professions.js"></script>
   <script src="/views/enemies.js"></script>
+  <script src="/views/hunt.js"></script>
   <script src="/app.js"></script>
 </body>
 </html>

--- a/public/app.js
+++ b/public/app.js
@@ -16,6 +16,7 @@ function routeFromPath(path) {
   if (path === '/enchant')              return { viewName: 'enchant', params: {} };
   if (path === '/professions')          return { viewName: 'professions', params: {} };
   if (path === '/enemies')              return { viewName: 'enemies', params: {} };
+  if (path === '/hunt')                 return { viewName: 'hunt',    params: {} };
   if (path === '/weapon-stats')         return { viewName: 'weapons', params: {} };
   const m = path.match(/^\/shop\/([^/]+)$/);
   if (m) return { viewName: 'shop', params: { shopKey: m[1] } };

--- a/public/game.css
+++ b/public/game.css
@@ -148,6 +148,23 @@ h1 { color: #c0a060; letter-spacing: 0.12em; font-size: 1.3rem; }
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
+.battle-again-btn {
+  display: inline-block;
+  margin-top: 10px;
+  padding: 8px 16px;
+  background: #1f3a30;
+  border: 1px solid #3a6650;
+  color: #88c8a0;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+.battle-again-btn:hover {
+  background: #3a6650;
+  color: #ffffff;
+}
 .action-buttons { display: flex; gap: 8px; flex-wrap: wrap; }
 .action-btn {
   background: #1e2e4a;

--- a/public/game.css
+++ b/public/game.css
@@ -233,19 +233,19 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
   border: 1px solid var(--border);
   border-bottom: none;
   border-radius: 6px 6px 0 0;
-  padding: 6px 12px;
+  padding: 8px 12px;
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted);
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
+  flex-direction: column;
+  gap: 6px;
 }
 #log-filters {
   display: flex;
-  gap: 8px;
+  flex-wrap: wrap;
+  gap: 4px 12px;
   text-transform: none;
   letter-spacing: 0;
   font-size: 0.7rem;
@@ -253,10 +253,11 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
 #log-filters label {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
+  gap: 4px;
   color: var(--text-faint);
   cursor: pointer;
   user-select: none;
+  white-space: nowrap;
 }
 #log-filters input { accent-color: var(--gold); cursor: pointer; }
 #log-filters label:hover { color: var(--text-2); }
@@ -285,9 +286,10 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
 #combat-log p.tutorial-ooc { color: var(--buy); font-size: 0.72rem; border-left: 2px solid var(--buy-dim); padding-left: 6px; }
 
 /* Filter: hide categories the player has toggled off */
-#combat-log.hide-flavor    p.flavor    { display: none; }
-#combat-log.hide-mechanics p.mechanics { display: none; }
-#combat-log.hide-move      p.move      { display: none; }
+#combat-log.hide-flavor      p.flavor      { display: none; }
+#combat-log.hide-action-head p.action-head { display: none; }
+#combat-log.hide-mechanics   p.mechanics   { display: none; }
+#combat-log.hide-move        p.move        { display: none; }
 
 /* ---- Status ---- */
 #connection-status { font-size: 0.75rem; }

--- a/public/game.css
+++ b/public/game.css
@@ -187,6 +187,19 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
 .action-btn:hover { background: #233a4d; border-color: var(--buy); }
 .action-btn.selected { background: var(--teal-bg); border-color: var(--teal); color: var(--teal-bright); }
 .action-btn.unaffordable { opacity: 0.35; cursor: not-allowed; }
+.action-tag {
+  display: inline-block;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 1px 6px;
+  margin-right: 6px;
+  border-radius: 3px;
+  background: var(--bg-darkest);
+  color: var(--text-muted);
+  vertical-align: middle;
+}
+.action-btn.selected .action-tag { background: var(--teal-dim); color: var(--text); }
 .submit-btn {
   background: var(--gold-bg);
   border: 1px solid var(--gold-dim);
@@ -220,6 +233,32 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
 .res-bar-bg { background: var(--bg-darkest); border-radius: 3px; height: 4px; overflow: hidden; margin-top: 6px; }
 .res-bar { height: 100%; border-radius: 3px; background: var(--buy); transition: width 0.3s; }
 .telegraph { font-size: 0.7rem; color: var(--gold); margin-top: 7px; font-style: italic; letter-spacing: 0.04em; }
+
+.status-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  margin-top: 6px;
+}
+.badge {
+  font-size: 0.62rem;
+  padding: 2px 5px;
+  border-radius: 3px;
+  font-family: monospace;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.badge i { font-style: normal; opacity: 0.65; font-weight: normal; font-size: 0.92em; }
+.badge-block   { background: var(--buy-bg);  color: var(--buy-bright);   border: 1px solid var(--buy-dim); }
+.badge-shield  { background: var(--buy-bg);  color: var(--buy-bright);   border: 1px solid var(--buy); }
+.badge-dot     { background: var(--warn-bg); color: var(--warn-bright);  border: 1px solid var(--warn-dim); }
+.badge-buff    { background: var(--teal-bg); color: var(--teal-bright);  border: 1px solid var(--teal-dim); }
+.badge-debuff  { background: var(--warn-bg); color: var(--warn);         border: 1px solid var(--warn-dim); }
+.badge-reflect { background: var(--gold-bg); color: var(--gold);         border: 1px solid var(--gold-dim); }
 
 /* ---- Combat log ---- */
 #right-col {

--- a/public/game.css
+++ b/public/game.css
@@ -1,8 +1,8 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  background: #1a1a2e;
-  color: #e0e0e0;
+  background: var(--bg);
+  color: var(--text);
   font-family: 'Segoe UI', sans-serif;
   display: flex;
   flex-direction: column;
@@ -12,18 +12,18 @@ body {
   gap: 16px;
 }
 
-h1 { color: #c0a060; letter-spacing: 0.12em; font-size: 1.3rem; }
+h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
 
 #status-bar {
   display: flex;
   gap: 12px;
   align-items: center;
   font-size: 0.85rem;
-  color: #888;
+  color: var(--text-muted);
 }
-.sep { color: #444; }
-#turn-label { color: #c0a060; font-weight: bold; }
-#phase-label { text-transform: uppercase; letter-spacing: 0.08em; color: #aaa; }
+.sep { color: var(--text-vdim); }
+#turn-label { color: var(--gold); font-weight: bold; }
+#phase-label { text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); }
 
 #main-layout {
   display: flex;
@@ -133,8 +133,8 @@ h1 { color: #c0a060; letter-spacing: 0.12em; font-size: 1.3rem; }
 
 /* ---- Action panel ---- */
 #action-panel {
-  background: #12192e;
-  border: 1px solid #2a3a5a;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 12px 16px;
   min-height: 56px;
@@ -144,7 +144,7 @@ h1 { color: #c0a060; letter-spacing: 0.12em; font-size: 1.3rem; }
 }
 .action-title {
   font-size: 0.8rem;
-  color: #8898aa;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
@@ -152,9 +152,9 @@ h1 { color: #c0a060; letter-spacing: 0.12em; font-size: 1.3rem; }
   display: inline-block;
   margin-top: 10px;
   padding: 8px 16px;
-  background: #1f3a30;
-  border: 1px solid #3a6650;
-  color: #88c8a0;
+  background: var(--teal-bg);
+  border: 1px solid var(--teal-dim);
+  color: var(--teal-bright);
   border-radius: 4px;
   font-size: 0.9rem;
   font-weight: 600;
@@ -162,8 +162,8 @@ h1 { color: #c0a060; letter-spacing: 0.12em; font-size: 1.3rem; }
   cursor: pointer;
 }
 .battle-again-btn:hover {
-  background: #3a6650;
-  color: #ffffff;
+  background: var(--teal-dim);
+  color: var(--text);
 }
 .action-buttons { display: flex; gap: 8px; flex-wrap: wrap; }
 .action-btn {
@@ -196,8 +196,8 @@ h1 { color: #c0a060; letter-spacing: 0.12em; font-size: 1.3rem; }
 /* ---- Combatant cards ---- */
 #combatant-list { display: flex; gap: 12px; }
 .combatant-card {
-  background: #16213e;
-  border: 1px solid #2a3a5a;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 10px 14px;
   min-width: 130px;
@@ -205,13 +205,13 @@ h1 { color: #c0a060; letter-spacing: 0.12em; font-size: 1.3rem; }
 .combatant-card.team-a { border-color: #4a90d9; }
 .combatant-card.team-b { border-color: #d94a4a; }
 .combatant-card h3 { font-size: 0.9rem; margin-bottom: 2px; }
-.weapon-name { font-size: 0.7rem; color: #7090b0; margin-bottom: 6px; }
-.hp-bar-bg { background: #0d0d1a; border-radius: 3px; height: 6px; overflow: hidden; }
+.weapon-name { font-size: 0.7rem; color: var(--text-muted); margin-bottom: 6px; }
+.hp-bar-bg { background: var(--bg-darkest); border-radius: 3px; height: 6px; overflow: hidden; }
 .hp-bar { height: 100%; border-radius: 3px; transition: width 0.3s, background 0.3s; }
-.hp-text { font-size: 0.75rem; color: #888; margin-top: 3px; }
-.res-bar-bg { background: #0d0d1a; border-radius: 3px; height: 4px; overflow: hidden; margin-top: 6px; }
-.res-bar { height: 100%; border-radius: 3px; background: #4a7a9b; transition: width 0.3s; }
-.telegraph { font-size: 0.7rem; color: #c0a060; margin-top: 7px; font-style: italic; letter-spacing: 0.04em; }
+.hp-text { font-size: 0.75rem; color: var(--text-faint); margin-top: 3px; }
+.res-bar-bg { background: var(--bg-darkest); border-radius: 3px; height: 4px; overflow: hidden; margin-top: 6px; }
+.res-bar { height: 100%; border-radius: 3px; background: var(--buy); transition: width 0.3s; }
+.telegraph { font-size: 0.7rem; color: var(--gold); margin-top: 7px; font-style: italic; letter-spacing: 0.04em; }
 
 /* ---- Combat log ---- */
 #right-col {
@@ -221,19 +221,19 @@ h1 { color: #c0a060; letter-spacing: 0.12em; font-size: 1.3rem; }
   gap: 0;
 }
 #log-header {
-  background: #12192e;
-  border: 1px solid #2a3a5a;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
   border-bottom: none;
   border-radius: 6px 6px 0 0;
   padding: 6px 12px;
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #667;
+  color: var(--text-muted);
 }
 #combat-log {
-  background: #0e141f;
-  border: 1px solid #2a3a5a;
+  background: var(--bg-deep);
+  border: 1px solid var(--border);
   border-radius: 0 0 6px 6px;
   padding: 10px 12px;
   height: 420px;
@@ -244,11 +244,11 @@ h1 { color: #c0a060; letter-spacing: 0.12em; font-size: 1.3rem; }
   font-size: 0.78rem;
   line-height: 1.4;
 }
-#combat-log p { color: #99aabb; border-bottom: 1px solid #1a2230; padding-bottom: 3px; }
-#combat-log p.turn-divider { color: #c0a060; font-weight: bold; border-bottom-color: #3a2a00; }
-#combat-log p.crit { color: #ffd060; font-weight: bold; }
-#combat-log p.tutorial-aside { color: #a8c8a0; font-style: italic; border-left: 2px solid #4a7a40; padding-left: 6px; }
-#combat-log p.tutorial-ooc { color: #7090c0; font-size: 0.72rem; border-left: 2px solid #304060; padding-left: 6px; }
+#combat-log p { color: var(--text-2); border-bottom: 1px solid var(--border-soft); padding-bottom: 3px; }
+#combat-log p.turn-divider { color: var(--gold); font-weight: bold; border-bottom-color: var(--gold-dim); }
+#combat-log p.crit { color: var(--gold-bright); font-weight: bold; }
+#combat-log p.tutorial-aside { color: var(--teal-bright); font-style: italic; border-left: 2px solid var(--teal-dim); padding-left: 6px; }
+#combat-log p.tutorial-ooc { color: var(--buy); font-size: 0.72rem; border-left: 2px solid var(--buy-dim); padding-left: 6px; }
 
 /* ---- Status ---- */
 #connection-status { font-size: 0.75rem; }

--- a/public/game.css
+++ b/public/game.css
@@ -238,7 +238,28 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
 }
+#log-filters {
+  display: flex;
+  gap: 8px;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 0.7rem;
+}
+#log-filters label {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--text-faint);
+  cursor: pointer;
+  user-select: none;
+}
+#log-filters input { accent-color: var(--gold); cursor: pointer; }
+#log-filters label:hover { color: var(--text-2); }
 #combat-log {
   background: var(--bg-deep);
   border: 1px solid var(--border);
@@ -254,9 +275,19 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
 }
 #combat-log p { color: var(--text-2); border-bottom: 1px solid var(--border-soft); padding-bottom: 3px; }
 #combat-log p.turn-divider { color: var(--gold); font-weight: bold; border-bottom-color: var(--gold-dim); }
-#combat-log p.crit { color: var(--gold-bright); font-weight: bold; }
+#combat-log p.crit         { color: var(--gold-bright); font-weight: bold; }
+#combat-log p.action-head  { color: var(--text); font-weight: 600; }
+#combat-log p.flavor       { color: var(--gold); font-style: italic; opacity: 0.85; padding-left: 8px; }
+#combat-log p.mechanics    { color: var(--text-muted); font-family: monospace; font-size: 0.72rem; padding-left: 8px; }
+#combat-log p.move         { color: var(--text-faint); font-size: 0.74rem; }
+#combat-log p.status       { color: var(--warn-bright); }
 #combat-log p.tutorial-aside { color: var(--teal-bright); font-style: italic; border-left: 2px solid var(--teal-dim); padding-left: 6px; }
 #combat-log p.tutorial-ooc { color: var(--buy); font-size: 0.72rem; border-left: 2px solid var(--buy-dim); padding-left: 6px; }
+
+/* Filter: hide categories the player has toggled off */
+#combat-log.hide-flavor    p.flavor    { display: none; }
+#combat-log.hide-mechanics p.mechanics { display: none; }
+#combat-log.hide-move      p.move      { display: none; }
 
 /* ---- Status ---- */
 #connection-status { font-size: 0.75rem; }

--- a/public/game.css
+++ b/public/game.css
@@ -43,16 +43,16 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
 #board {
   display: grid;
   gap: 3px;
-  background: #0d0d1a;
+  background: var(--bg-darkest);
   padding: 8px;
-  border: 2px solid #2a2a4a;
+  border: 1px solid var(--border);
   border-radius: 6px;
 }
 
 .cell {
   width: 72px;
   height: 72px;
-  background: #16213e;
+  background: var(--bg-surface);
   border-radius: 4px;
   display: flex;
   align-items: center;
@@ -69,49 +69,51 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
   bottom: 2px;
   right: 4px;
   font-size: 0.5rem;
-  color: #2a3050;
+  color: var(--text-vdim);
   pointer-events: none;
 }
 
-/* Obstacle */
-.cell.obstacle {
-  background: #2a1e10;
-  cursor: not-allowed;
-}
-.cell.obstacle::before {
-  content: '▪';
-  font-size: 2rem;
-  color: #7a5a3a;
-}
+/* Obstacle — earthy brown, kept off-palette by design (it's terrain) */
+.cell.obstacle { background: #2a1e10; cursor: not-allowed; }
+.cell.obstacle::before { content: '▪'; font-size: 2rem; color: #7a5a3a; }
 .cell.obstacle[data-state="damaged"]::before { color: #c08040; content: '▵'; }
 .cell.obstacle[data-state="destroyed"] { background: #1a1510; }
 .cell.obstacle[data-state="destroyed"]::before { content: '·'; color: #333; }
 
-/* Reachable highlight */
+/* Reachable highlight — palette buy-blue */
 .cell.reachable {
-  background: #0e2a4a;
+  background: var(--buy-bg);
   cursor: pointer;
-  outline-color: #2060a0;
+  outline-color: var(--buy-dim);
 }
-.cell.reachable:hover { background: #0e3a6a; outline-color: #4090d0; }
+.cell.reachable:hover { background: #233a4d; outline-color: var(--buy); }
 
-/* Selected move target */
+/* Selected move target — palette teal */
 .cell.move-target {
-  background: #0a3a1a;
-  outline-color: #30c060;
+  background: var(--teal-bg);
+  outline-color: var(--teal);
 }
 
 /* Path tiles — intermediate steps to the chosen destination */
 .cell.path-tile {
-  background: #0a2a14;
-  outline: 2px dashed #28804a;
+  background: var(--teal-bg);
+  outline: 2px dashed var(--teal-dim);
+  opacity: 0.7;
 }
 
-/* Targetable tiles */
-.cell.target-valid { cursor: crosshair; outline: 2px solid #904020; background: #1e1008; }
-.cell.target-valid:hover { background: #2e1810; outline-color: #e06030; }
-.cell.target-selected { cursor: crosshair; outline: 3px solid #ff4020; background: #2a0e08;
-  box-shadow: inset 0 0 14px #ff402055; }
+/* Targetable tiles — palette amaranth */
+.cell.target-valid {
+  cursor: crosshair;
+  outline: 2px solid var(--warn-dim);
+  background: var(--warn-bg);
+}
+.cell.target-valid:hover { background: #3d1f2a; outline-color: var(--warn); }
+.cell.target-selected {
+  cursor: crosshair;
+  outline: 3px solid var(--warn-bright);
+  background: #3d1f2a;
+  box-shadow: inset 0 0 14px rgba(226, 99, 132, 0.4);
+}
 
 /* Combatant tokens */
 .combatant {
@@ -173,31 +175,31 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
 }
 .action-buttons { display: flex; gap: 8px; flex-wrap: wrap; }
 .action-btn {
-  background: #1e2e4a;
-  border: 1px solid #3a5a8a;
+  background: var(--buy-bg);
+  border: 1px solid var(--buy-dim);
   border-radius: 4px;
-  color: #c0d8f0;
+  color: var(--buy-bright);
   padding: 6px 14px;
   font-size: 0.85rem;
   cursor: pointer;
   transition: background 0.1s, border-color 0.1s;
 }
-.action-btn:hover { background: #2a3e6a; border-color: #60a0e0; }
-.action-btn.selected { background: #1a4a2a; border-color: #40c060; color: #a0ffc0; }
+.action-btn:hover { background: #233a4d; border-color: var(--buy); }
+.action-btn.selected { background: var(--teal-bg); border-color: var(--teal); color: var(--teal-bright); }
 .action-btn.unaffordable { opacity: 0.35; cursor: not-allowed; }
 .submit-btn {
-  background: #3a2000;
-  border: 1px solid #c08020;
+  background: var(--gold-bg);
+  border: 1px solid var(--gold-dim);
   border-radius: 4px;
-  color: #ffd060;
+  color: var(--gold);
   padding: 7px 20px;
   font-size: 0.9rem;
   font-weight: bold;
   cursor: pointer;
   letter-spacing: 0.05em;
-  transition: background 0.1s;
+  transition: background 0.1s, color 0.1s;
 }
-.submit-btn:hover { background: #5a3000; }
+.submit-btn:hover { background: var(--gold-dim); color: var(--text); }
 
 /* ---- Combatant cards ---- */
 #combatant-list { display: flex; gap: 12px; }

--- a/public/game.css
+++ b/public/game.css
@@ -6,10 +6,16 @@ body {
   font-family: 'Segoe UI', sans-serif;
   display: flex;
   flex-direction: column;
-  align-items: center;
   min-height: 100vh;
+}
+
+#battle-shell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   padding: 20px;
   gap: 16px;
+  flex: 1;
 }
 
 h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }

--- a/public/game.js
+++ b/public/game.js
@@ -287,7 +287,7 @@ function renderActionPanel() {
       const again = document.createElement('a');
       again.href = '/app/hunt';
       again.className = 'battle-again-btn';
-      again.textContent = 'Hunt Again →';
+      again.textContent = 'Return to Town';
       actionPanelEl.appendChild(again);
     }
     return;

--- a/public/game.js
+++ b/public/game.js
@@ -377,7 +377,9 @@ function renderActionPanel() {
     const canAfford = action.cost <= 0 || action.cost <= player.resource;
     const btn = document.createElement('button');
     btn.className = `action-btn${actionIsSelected(action) ? ' selected' : ''}${canAfford ? '' : ' unaffordable'}`;
-    btn.textContent = action.label;
+    btn.innerHTML = action.choice && action.choice !== 'pass'
+      ? `<span class="action-tag">${action.choice}</span> ${action.label}`
+      : action.label;
     if (!canAfford) btn.disabled = true;
 
     const parts = [];
@@ -408,6 +410,19 @@ function renderActionPanel() {
   }
 }
 
+function statusBadgesHtml(status) {
+  if (!status) return '';
+  const badges = [];
+  // Block carries no rounds — it resets at end of turn — show as a single value.
+  if (status.block > 0)         badges.push(`<span class="badge badge-block">🛡 ${status.block}</span>`);
+  if (status.shield?.rounds > 0)  badges.push(`<span class="badge badge-shield">◆ ${status.shield.value} <i>${status.shield.rounds}r</i></span>`);
+  if (status.dot?.rounds > 0)     badges.push(`<span class="badge badge-dot">☠ ${status.dot.value} <i>${status.dot.rounds}r</i></span>`);
+  if (status.buff?.rounds > 0)    badges.push(`<span class="badge badge-buff">▲ ${status.buff.value} <i>${status.buff.rounds}r</i></span>`);
+  if (status.debuff?.rounds > 0)  badges.push(`<span class="badge badge-debuff">▼ ${status.debuff.value} <i>${status.debuff.rounds}r</i></span>`);
+  if (status.reflect?.rounds > 0) badges.push(`<span class="badge badge-reflect">↺ ${status.reflect.value} <i>${status.reflect.rounds}r</i></span>`);
+  return badges.length ? `<div class="status-badges">${badges.join('')}</div>` : '';
+}
+
 function renderCombatantList() {
   combatantListEl.innerHTML = '';
   if (!state) return;
@@ -427,6 +442,7 @@ function renderCombatantList() {
       <div class="hp-text">${c.hp} / ${c.maxHp} HP</div>
       <div class="res-bar-bg"><div class="res-bar" style="width:${resPct}%"></div></div>
       <div class="hp-text">${c.resource ?? '?'} / ${c.maxResource ?? '?'} ${c.resourceName ?? ''}</div>
+      ${statusBadgesHtml(c.status)}
       ${telegraph ? `<div class="telegraph">${telegraph}</div>` : ''}
     `;
     combatantListEl.appendChild(card);
@@ -485,13 +501,9 @@ function onCellClick(x, y) {
   }
 
   if (ui.phase === 'selecting_target') {
-    if (clicked?.id === ui.selected?.id) {
-      ui.phase = 'selecting_action';
-      ui.action = null;
-      ui.targetTile = null;
-      render();
-      return;
-    }
+    // Don't bump back to action select on own-tile click — the Back button does
+    // that, and intercepting clicks here blocks legitimate target-tile picks
+    // (incl. self-targeting Heal/Buff actions).
     const fromPos = ui.moveTo ?? ui.selected?.pos;
     if (fromPos && ui.action && computeTargetableTiles(ui.action, fromPos).has(k)) {
       ui.targetTile = { x, y };

--- a/public/game.js
+++ b/public/game.js
@@ -242,6 +242,13 @@ function render() {
 function renderBoard() {
   const { width, height, obstacles } = state.board;
   boardEl.style.gridTemplateColumns = `repeat(${width}, 72px)`;
+  // Lock #left-col to the board's pixel width. Otherwise the action panel's
+  // flex-wrap button row can be intrinsically wider than the board, which
+  // stretches the column on action-pick frames and snaps it back on
+  // waiting/idle frames — visible as the grid "jumping" and a blank gap
+  // appearing between the board and the combat log.
+  const boardPxWidth = width * 72 + (width - 1) * 3 + 18; // cells + gaps + padding(16) + border(2)
+  document.getElementById('left-col').style.width = `${boardPxWidth}px`;
   boardEl.innerHTML = '';
 
   const obstacleMap = new Map(obstacles.map(o => [`${o.pos.x},${o.pos.y}`, o]));

--- a/public/game.js
+++ b/public/game.js
@@ -25,6 +25,32 @@ const phaseLabelEl    = document.getElementById('phase-label');
 const connStatusEl    = document.getElementById('connection-status');
 const logEl           = document.getElementById('combat-log');
 
+// ---- Combat log filters ----
+const LOG_FILTER_KEY = 'idya.log_filters';
+function loadLogFilters() {
+  try { return JSON.parse(localStorage.getItem(LOG_FILTER_KEY) ?? '{}'); }
+  catch (_) { return {}; }
+}
+function applyLogFilters(state) {
+  for (const key of ['flavor', 'mechanics', 'move']) {
+    logEl.classList.toggle(`hide-${key}`, state[key] === false);
+    const box = document.querySelector(`#log-filters input[data-filter="${key}"]`);
+    if (box) box.checked = state[key] !== false;
+  }
+}
+(function initLogFilters() {
+  const state = loadLogFilters();
+  applyLogFilters(state);
+  document.querySelectorAll('#log-filters input[data-filter]').forEach(box => {
+    box.addEventListener('change', () => {
+      const next = loadLogFilters();
+      next[box.dataset.filter] = box.checked;
+      localStorage.setItem(LOG_FILTER_KEY, JSON.stringify(next));
+      applyLogFilters(next);
+    });
+  });
+})();
+
 // ---- Socket ----
 socket.on('connect', () => {
   connStatusEl.textContent = 'Connected';
@@ -511,11 +537,25 @@ function resetSession() {
 }
 
 // ---- Log ----
+function classifyLogLine(line) {
+  if (line.startsWith('━━━'))                                    return 'turn-divider';
+  if (line.startsWith('★'))                                      return 'crit';
+  if (line.includes('is defeated'))                              return 'status';
+  if (/ moves \(\d+,\d+\) → \(\d+,\d+\)\.?$/.test(line))         return 'move';
+  if (line.includes('yields to') || line.includes('tie for the same tile')) return 'move';
+  if (/^Roll:/.test(line) || /^DOT:/.test(line))                 return 'mechanics';
+  if (line.includes('takes') && line.includes('DOT damage'))     return 'mechanics';
+  if (line.includes('damage reflected to'))                      return 'mechanics';
+  if (/expired|wore off/i.test(line))                            return 'status';
+  if (line.includes(' — '))                                      return 'action-head';
+  // Default: narrative prose from the action_string template.
+  return 'flavor';
+}
+
 function appendLog(lines, cls = '') {
   for (const line of lines) {
     const p = document.createElement('p');
-    const autoClass = line.startsWith('★') ? 'crit' : '';
-    p.className = cls || autoClass;
+    p.className = cls || classifyLogLine(line);
     p.textContent = line;
     logEl.appendChild(p);
   }

--- a/public/game.js
+++ b/public/game.js
@@ -284,11 +284,11 @@ function renderActionPanel() {
   if (ui.phase === 'ended') {
     actionPanelEl.innerHTML = '<div class="action-title">Battle ended.</div>';
     if (!isTutorial) {
-      const hint = document.createElement('div');
-      hint.className = 'action-title';
-      hint.style.marginTop = '8px';
-      hint.textContent = 'Return to Discord to start another battle.';
-      actionPanelEl.appendChild(hint);
+      const again = document.createElement('a');
+      again.href = '/app/hunt';
+      again.className = 'battle-again-btn';
+      again.textContent = 'Hunt Again →';
+      actionPanelEl.appendChild(again);
     }
     return;
   }

--- a/public/game.js
+++ b/public/game.js
@@ -31,8 +31,9 @@ function loadLogFilters() {
   try { return JSON.parse(localStorage.getItem(LOG_FILTER_KEY) ?? '{}'); }
   catch (_) { return {}; }
 }
+const LOG_FILTER_KEYS = ['flavor', 'action-head', 'mechanics', 'move'];
 function applyLogFilters(state) {
-  for (const key of ['flavor', 'mechanics', 'move']) {
+  for (const key of LOG_FILTER_KEYS) {
     logEl.classList.toggle(`hide-${key}`, state[key] === false);
     const box = document.querySelector(`#log-filters input[data-filter="${key}"]`);
     if (box) box.checked = state[key] !== false;

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Idya Combat</title>
   <link rel="icon" type="image/png" href="/favicon.png">
+  <link rel="stylesheet" href="/layout.css">
   <link rel="stylesheet" href="/game.css">
   <script>if (location.port === '3000') document.title += ' — Dev';</script>
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -31,9 +31,10 @@
         <div id="log-header">
           <span>Combat Log</span>
           <div id="log-filters">
-            <label><input type="checkbox" data-filter="flavor"    checked> Flavor</label>
-            <label><input type="checkbox" data-filter="mechanics" checked> Mechanics</label>
-            <label><input type="checkbox" data-filter="move"      checked> Moves</label>
+            <label><input type="checkbox" data-filter="flavor"     checked> Flavor</label>
+            <label><input type="checkbox" data-filter="action-head" checked> Actions</label>
+            <label><input type="checkbox" data-filter="mechanics"  checked> Mechanics</label>
+            <label><input type="checkbox" data-filter="move"       checked> Moves</label>
           </div>
         </div>
         <div id="combat-log"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -10,29 +10,39 @@
   <script>if (location.port === '3000') document.title += ' — Dev';</script>
 </head>
 <body>
-  <h1>IDYA COMBAT</h1>
+  <div id="layout-root"></div>
 
-  <div id="status-bar">
-    <span id="turn-label">Turn 1</span>
-    <span class="sep">·</span>
-    <span id="phase-label">waiting</span>
-    <span class="sep">·</span>
-    <span id="connection-status" class="disconnected">Connecting...</span>
+  <div id="battle-shell">
+    <div id="status-bar">
+      <span id="turn-label">Turn 1</span>
+      <span class="sep">·</span>
+      <span id="phase-label">waiting</span>
+      <span class="sep">·</span>
+      <span id="connection-status" class="disconnected">Connecting...</span>
+    </div>
+
+    <div id="main-layout">
+      <div id="left-col">
+        <div id="board"></div>
+        <div id="action-panel"></div>
+        <div id="combatant-list"></div>
+      </div>
+      <div id="right-col">
+        <div id="log-header">Combat Log</div>
+        <div id="combat-log"></div>
+      </div>
+    </div>
   </div>
 
-  <div id="main-layout">
-    <div id="left-col">
-      <div id="board"></div>
-      <div id="action-panel"></div>
-      <div id="combatant-list"></div>
-    </div>
-    <div id="right-col">
-      <div id="log-header">Combat Log</div>
-      <div id="combat-log"></div>
-    </div>
-  </div>
-
+  <script src="/auth.js"></script>
+  <script src="/layout.js"></script>
   <script src="/socket.io/socket.io.js"></script>
   <script src="/game.js"></script>
+  <script>
+    (async function initBattleLayout() {
+      await claimAuthFromUrl();
+      await mountLayout({ title: 'Combat' });
+    })();
+  </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,14 @@
         <div id="combatant-list"></div>
       </div>
       <div id="right-col">
-        <div id="log-header">Combat Log</div>
+        <div id="log-header">
+          <span>Combat Log</span>
+          <div id="log-filters">
+            <label><input type="checkbox" data-filter="flavor"    checked> Flavor</label>
+            <label><input type="checkbox" data-filter="mechanics" checked> Mechanics</label>
+            <label><input type="checkbox" data-filter="move"      checked> Moves</label>
+          </div>
+        </div>
         <div id="combat-log"></div>
       </div>
     </div>

--- a/public/layout.js
+++ b/public/layout.js
@@ -1,7 +1,5 @@
 // Shared header layout — persistent across navigation.
 
-const PROF_SHOP_LAYOUT = { lumberjack: 'lumberjack', blacksmith: 'blacksmith', enchanter: 'enchanting_shop' };
-
 function layoutEsc(s) {
   return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
@@ -43,21 +41,15 @@ function renderLayout() {
 
   const spriteUrl = layoutData.spriteToken ? `${layoutData.spriteCdn}/${layoutData.spriteToken}.png` : null;
 
-  const profCards = Object.entries(layoutData.professions).map(([key, p]) => {
-    const pct       = (p.level / p.maxLevel) * 100;
-    const atMax     = p.level >= p.maxLevel;
-    const canAfford = p.nextCost != null && layoutData.korel >= p.nextCost;
-    const cost      = p.nextCost != null ? p.nextCost.toLocaleString() : null;
+  const profCards = Object.entries(layoutData.professions).map(([_key, p]) => {
+    const pct   = (p.level / p.maxLevel) * 100;
+    const atMax = p.level >= p.maxLevel;
+    const cost  = p.nextCost != null ? p.nextCost.toLocaleString() : null;
     return `<div class="layout-prof">
       <p class="layout-prof-name">${layoutEsc(p.label)}</p>
       <p class="layout-prof-level">${p.level}<span> / ${p.maxLevel}</span></p>
       <div class="layout-prof-bar-bg"><div class="layout-prof-bar" style="width:${pct}%"></div></div>
-      <div class="layout-prof-footer">
-        <p class="layout-prof-meta">${atMax ? 'Mastered' : cost != null ? `Next: ${cost} korel` : 'Cap'}</p>
-        ${!atMax && cost != null
-          ? `<button class="layout-train-btn" onclick="layoutTrain('${PROF_SHOP_LAYOUT[key]}')" ${canAfford ? '' : 'disabled'}>Train</button>`
-          : ''}
-      </div>
+      <p class="layout-prof-meta">${atMax ? 'Mastered' : cost != null ? `Next: ${cost} korel` : 'Cap'}</p>
     </div>`;
   }).join('');
 
@@ -77,14 +69,3 @@ function renderLayout() {
     </header>`;
 }
 
-async function layoutTrain(shopKey) {
-  const res = await fetch(`/api/shop/${shopKey}/train`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({}),
-  });
-  const body = await res.json();
-  if (window.showToast) window.showToast(body.message ?? body.error ?? 'Error');
-  else alert(body.message ?? body.error ?? 'Error');
-  if (body.success) await mountLayout();
-}

--- a/public/views/bench.css
+++ b/public/views/bench.css
@@ -67,7 +67,7 @@ code  { background: var(--bg-darkest); padding: 2px 7px; border-radius: 3px; col
 .recipe-name { font-size: 0.86rem; color: var(--text-2); transition: color 0.1s; }
 .recipe-row:hover .recipe-name:not(.dim),
 .recipe-row.open  .recipe-name:not(.dim) { color: var(--gold-bright); }
-.recipe-name.dim { color: var(--text-vdim); }
+.recipe-name.dim { color: var(--text-faint); }
 
 .recipe-badge {
   font-size: 0.68rem;

--- a/public/views/character.css
+++ b/public/views/character.css
@@ -116,6 +116,37 @@
 }
 .char-equip-btn:hover { background: var(--teal-dim); color: var(--text); }
 
+.char-prof-table { width: 100%; border-collapse: collapse; }
+.char-prof-table td {
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.char-prof-name  { font-size: 0.84rem; color: var(--text-2); }
+.char-prof-level {
+  font-size: 0.78rem;
+  color: var(--gold);
+  font-family: monospace;
+}
+.char-prof-level span { color: var(--text-faint); }
+.char-prof-cost  {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: monospace;
+  text-align: right;
+}
+.char-prof-action { text-align: right; width: 80px; }
+.char-train-btn {
+  font-size: 0.72rem;
+  padding: 4px 12px;
+  background: var(--teal-bg);
+  color: var(--teal-bright);
+  border: 1px solid var(--teal-dim);
+  border-radius: 3px;
+  cursor: pointer;
+}
+.char-train-btn:hover:not(:disabled) { background: var(--teal-dim); color: var(--text); }
+.char-train-btn:disabled { opacity: 0.35; cursor: default; }
+
 .char-empty { padding: 20px; color: var(--text-faint); font-style: italic; text-align: center; }
 
 #char-toast {

--- a/public/views/character.js
+++ b/public/views/character.js
@@ -25,6 +25,8 @@
     render();
   }
 
+  const PROF_SHOP = { lumberjack: 'lumberjack', blacksmith: 'blacksmith', enchanter: 'enchanting_shop' };
+
   function render() {
     const body = document.getElementById('char-body');
     const c = data;
@@ -42,6 +44,23 @@
         </td>
       </tr>
     `).join('');
+
+    const profRows = Object.entries(c.professions ?? {}).map(([key, p]) => {
+      const atMax     = p.level >= p.maxLevel;
+      const canAfford = p.nextCost != null && (c.korel ?? 0) >= p.nextCost;
+      const cost      = p.nextCost != null ? p.nextCost.toLocaleString() : null;
+      return `
+        <tr>
+          <td class="char-prof-name">${esc(p.label)}</td>
+          <td class="char-prof-level">Lv ${p.level} <span>/ ${p.maxLevel}</span></td>
+          <td class="char-prof-cost">${atMax ? 'Mastered' : cost != null ? `${cost} korel` : 'Cap'}</td>
+          <td class="char-prof-action">
+            ${!atMax && cost != null
+              ? `<button class="char-train-btn" onclick="Views.character.train('${esc(PROF_SHOP[key])}')" ${canAfford ? '' : 'disabled'}>Train</button>`
+              : ''}
+          </td>
+        </tr>`;
+    }).join('');
 
     body.innerHTML = `
       <section class="char-hero">
@@ -64,6 +83,12 @@
         </div>
       </section>
 
+      ${profRows ? `
+      <section class="char-section">
+        <h3 class="char-section-label">Professions</h3>
+        <table class="char-prof-table"><tbody>${profRows}</tbody></table>
+      </section>` : ''}
+
       <section class="char-section">
         <h3 class="char-section-label">Weapons</h3>
         ${c.weapons.length === 0
@@ -71,6 +96,20 @@
           : `<table class="char-weapon-table"><tbody>${weaponRows}</tbody></table>`}
       </section>
     `;
+  }
+
+  async function train(shopKey) {
+    const res = await fetch(`/api/shop/${shopKey}/train`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const r = await res.json();
+    toast(r.message ?? r.error ?? 'Error', r.success === true);
+    if (r.success) {
+      await mountLayout();
+      await loadData();
+    }
   }
 
   async function equip(weaponId) {
@@ -99,5 +138,5 @@
   }
 
   window.Views = window.Views ?? {};
-  window.Views.character = { mount, unmount, equip };
+  window.Views.character = { mount, unmount, equip, train };
 })();

--- a/public/views/hunt.css
+++ b/public/views/hunt.css
@@ -1,0 +1,168 @@
+/* View: Hunt — bait card grid */
+
+#hunt-body {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 20px 24px 32px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.hunt-head {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.hunt-title {
+  font-size: 1.4rem;
+  color: var(--gold);
+  font-weight: 600;
+}
+.hunt-sub {
+  font-size: 0.82rem;
+  color: var(--text-faint);
+  font-style: italic;
+}
+
+.hunt-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 14px;
+}
+
+.hunt-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  display: flex;
+  overflow: hidden;
+}
+
+.hunt-card-art {
+  flex: 0 0 96px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-deep);
+  border-right: 1px solid var(--border-soft);
+  padding: 12px;
+}
+.hunt-card-art img {
+  width: 72px;
+  height: 72px;
+  image-rendering: pixelated;
+  object-fit: contain;
+}
+
+.hunt-card-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px 14px;
+  min-width: 0;
+}
+
+.hunt-card-headline {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+}
+.hunt-enemy-name {
+  font-size: 1rem;
+  color: var(--text);
+  font-weight: 600;
+}
+.hunt-hp {
+  font-size: 0.78rem;
+  color: var(--warn-bright);
+  font-family: monospace;
+  flex-shrink: 0;
+}
+
+.hunt-bait-line {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.78rem;
+  color: var(--text-faint);
+  padding: 4px 0;
+  border-bottom: 1px dashed var(--border-soft);
+}
+.hunt-bait-name { letter-spacing: 0.02em; }
+.hunt-bait-qty { color: var(--teal-bright); font-family: monospace; }
+
+.hunt-drops {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.hunt-drops-label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-faint);
+}
+.hunt-drops-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.hunt-drops-list li {
+  font-size: 0.78rem;
+  color: var(--text-2);
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.hunt-drop-range {
+  color: var(--text-faint);
+  font-family: monospace;
+}
+
+.hunt-start {
+  margin-top: auto;
+  padding: 8px 14px;
+  background: var(--teal-bg);
+  border: 1px solid var(--teal-dim);
+  color: var(--teal-bright);
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.hunt-start:hover:not(:disabled) {
+  background: var(--teal-dim);
+  color: var(--text);
+}
+.hunt-start:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.hunt-empty {
+  padding: 40px 20px;
+  color: var(--text-faint);
+  font-style: italic;
+  text-align: center;
+}
+.hunt-empty a { color: var(--gold); }
+.hunt-empty a:hover { text-decoration: underline; }
+
+.hunt-error {
+  margin-top: 10px;
+  padding: 10px 14px;
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-dim);
+  border-radius: 4px;
+  color: var(--warn-bright);
+  font-size: 0.85rem;
+}

--- a/public/views/hunt.js
+++ b/public/views/hunt.js
@@ -1,0 +1,152 @@
+// View: Hunt — pick a bait, head into the forest.
+(function() {
+  let data = null;
+  let starting = false;
+
+  function esc(s) {
+    return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function dropSummary(d) {
+    const field = d.field ?? [];
+    if (field.length === 0) return `${esc(d.name)}`;
+    const min = Math.min(...field);
+    const max = Math.max(...field);
+    const range = min === max ? `${min}` : `${min}–${max}`;
+    return `${esc(d.name)} <span class="hunt-drop-range">${range}</span>`;
+  }
+
+  async function mount(root) {
+    setLayoutTitle('Hunt');
+    root.innerHTML = `<div id="hunt-body"><p class="hunt-empty">Loading…</p></div>`;
+    window.addEventListener('layout-changed', layoutChangedHandler);
+    await loadData();
+  }
+
+  function layoutChangedHandler() { if (data) loadData(); }
+
+  async function loadData() {
+    const res = await fetch('/api/hunt');
+    const body = document.getElementById('hunt-body');
+    if (!res.ok) {
+      body.innerHTML = `<p class="hunt-empty">Could not load hunt info.</p>`;
+      return;
+    }
+    data = await res.json();
+    render();
+  }
+
+  function render() {
+    const body = document.getElementById('hunt-body');
+
+    if (!data.tutorial_complete) {
+      body.innerHTML = `
+        <header class="hunt-head">
+          <h1 class="hunt-title">Sulkupa Forest</h1>
+          <p class="hunt-sub">The forest is closed to you for now.</p>
+        </header>
+        <p class="hunt-empty">Talk to Fendalok first — use <code>/battle</code> in Discord to begin the tutorial.</p>
+      `;
+      return;
+    }
+
+    if (data.baits.length === 0) {
+      body.innerHTML = `
+        <header class="hunt-head">
+          <h1 class="hunt-title">Sulkupa Forest</h1>
+          <p class="hunt-sub">The trees are dense this far out. You need bait to draw something in.</p>
+        </header>
+        <p class="hunt-empty">No bait in your pack. Pick some up at the <a href="/app/shop/general_store">General Store</a>.</p>
+      `;
+      bindNav(body);
+      return;
+    }
+
+    const cardsHtml = data.baits.map(b => `
+      <article class="hunt-card" data-bait="${esc(b.bait_id)}">
+        <div class="hunt-card-art">
+          <img src="${esc(b.enemy_sprite)}" alt="${esc(b.enemy_name)}" onerror="this.style.visibility='hidden'">
+        </div>
+        <div class="hunt-card-body">
+          <div class="hunt-card-headline">
+            <h2 class="hunt-enemy-name">${esc(b.enemy_name)}</h2>
+            <span class="hunt-hp">${b.enemy_health} HP</span>
+          </div>
+          <div class="hunt-bait-line">
+            <span class="hunt-bait-name">${esc(b.bait_name)}</span>
+            <span class="hunt-bait-qty">×${b.quantity}</span>
+          </div>
+          ${b.drops.length > 0 ? `
+            <div class="hunt-drops">
+              <p class="hunt-drops-label">Drops</p>
+              <ul class="hunt-drops-list">
+                ${b.drops.map(d => `<li>${dropSummary(d)}</li>`).join('')}
+              </ul>
+            </div>
+          ` : ''}
+          <button class="hunt-start" data-bait="${esc(b.bait_id)}">Start Hunt</button>
+        </div>
+      </article>
+    `).join('');
+
+    body.innerHTML = `
+      <header class="hunt-head">
+        <h1 class="hunt-title">Sulkupa Forest</h1>
+        <p class="hunt-sub">Pick a bait. One bait is consumed each hunt.</p>
+      </header>
+      <div class="hunt-grid">${cardsHtml}</div>
+      <p id="hunt-error" class="hunt-error" hidden></p>
+    `;
+
+    body.querySelectorAll('.hunt-start').forEach(btn => {
+      btn.addEventListener('click', () => startHunt(btn.dataset.bait, btn));
+    });
+    bindNav(body);
+  }
+
+  function bindNav(root) {
+    root.querySelectorAll('a[href^="/app/"]').forEach(a => {
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        const path = a.getAttribute('href').slice(4);
+        history.pushState(null, '', a.getAttribute('href'));
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      });
+    });
+  }
+
+  async function startHunt(baitId, btn) {
+    if (starting) return;
+    starting = true;
+    const err = document.getElementById('hunt-error');
+    if (err) err.hidden = true;
+    btn.disabled = true;
+    btn.textContent = 'Entering…';
+    try {
+      const res = await fetch('/api/hunt/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bait_id: baitId }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.session_url) {
+        throw new Error(json.error || 'Could not start the hunt.');
+      }
+      location.href = json.session_url;
+    } catch (e) {
+      starting = false;
+      btn.disabled = false;
+      btn.textContent = 'Start Hunt';
+      if (err) { err.textContent = e.message; err.hidden = false; }
+    }
+  }
+
+  function unmount() {
+    window.removeEventListener('layout-changed', layoutChangedHandler);
+    data = null;
+    starting = false;
+  }
+
+  window.Views = window.Views ?? {};
+  window.Views.hunt = { mount, unmount };
+})();

--- a/public/views/shop.js
+++ b/public/views/shop.js
@@ -93,7 +93,7 @@
 
     for (const item of forSale) {
       const oos       = !item.infinite && item.stock === 0;
-      const stockText = item.infinite ? 'Always in stock' : `${item.stock} in stock`;
+      const stockText = item.infinite ? 'Always in stock' : `${item.stock}/${item.stock_max} in stock`;
       const maxQty    = item.infinite ? 9999 : item.stock;
       const qty       = getCartQty('buys', item.id);
       const el = document.createElement('div');
@@ -123,7 +123,7 @@
 
       for (const w of weaponListings) {
         const oos       = !w.infinite && w.stock === 0;
-        const stockText = w.infinite ? 'Always in stock' : `${w.stock} in stock`;
+        const stockText = w.infinite ? 'Always in stock' : `${w.stock}/${w.stock_max} in stock`;
         const maxQty    = w.infinite ? 99 : Math.min(99, w.stock);
         const qty       = getBuyWeaponQty(w.weapon_key);
         const el = document.createElement('div');
@@ -168,7 +168,7 @@
       const maxQty = Math.min(inv.quantity, room);
       const qty   = getCartQty('sells', inv.item_id);
       const note  = room === 0
-        ? 'shop is fully stocked'
+        ? `shop is fully stocked · own ${inv.quantity}`
         : `${si.sell} korel · own ${inv.quantity}`;
       const el = document.createElement('div');
       el.className = 'shop-item';

--- a/public/views/upgrade.js
+++ b/public/views/upgrade.js
@@ -84,7 +84,7 @@
         <span class="budget-used">${w.weapon_total} / ${w.weapon_cap} upgrades used</span>
         ${atCap
           ? '<span class="budget-cap">Budget full — level up to expand</span>'
-          : nextCost ? `<span class="budget-next">Next: <b>${nextCost.quantity}</b> ${esc(nextCost.material)}</span>` : ''}
+          : nextCost ? `<span class="budget-next">Next: <b>${nextCost.quantity}</b> ${esc(nextCost.material_name ?? nextCost.material)}</span>` : ''}
       </div>`;
 
     let sectionsHtml = '';

--- a/src/combat/combat_session.ts
+++ b/src/combat/combat_session.ts
@@ -23,6 +23,15 @@ export interface WeaponInfo {
   actions: ActionInfo[];
 }
 
+export interface CombatantStatus {
+  block:   number;
+  dot:     { value: number; rounds: number };
+  buff:    { value: number; rounds: number };
+  debuff:  { value: number; rounds: number };
+  reflect: { value: number; rounds: number };
+  shield:  { value: number; rounds: number };
+}
+
 export interface Combatant {
   id: string;
   name: string;
@@ -37,6 +46,7 @@ export interface Combatant {
   teamId: string;
   weaponInfo: WeaponInfo;
   sprite?: string;
+  status?: CombatantStatus;
 }
 
 export interface CombatantMeta {
@@ -97,10 +107,23 @@ export class CombatSession {
   }
 
   toState(): SessionState {
+    const combatants = this.combatants.map(c => {
+      const meta = this.meta.get(c.id);
+      const s = meta?.state;
+      const status = s ? {
+        block:   s.block,
+        dot:     { ...s.dot     },
+        buff:    { ...s.buff    },
+        debuff:  { ...s.debuff  },
+        reflect: { ...s.reflect },
+        shield:  { ...s.shield  },
+      } : undefined;
+      return { ...c, status };
+    });
     return {
       id: this.id,
       board: this.board.toJSON(),
-      combatants: this.combatants,
+      combatants,
       teams: this.teams.map(t => ({ id: t.id, name: t.name })),
       turn: this.turn,
       phase: this.phase,

--- a/src/combat/resolution.ts
+++ b/src/combat/resolution.ts
@@ -233,6 +233,18 @@ export function resolveIntents(
     });
   }
 
+  // If direct damage already decided the fight, end here — don't tick DOT on a
+  // corpse, and don't let a DOT-on-player kill them post-victory.
+  let aliveTeams = session.teams.filter(t => t.combatants.length > 0);
+  if (aliveTeams.length < 2) {
+    // Single-player tie-break (both teams wiped in the same round): player wins.
+    const winner = aliveTeams[0]?.id ?? 'team-a';
+    session.turn++;
+    session.phase = 'ended';
+    session.pendingIntents.clear();
+    return { log, winner };
+  }
+
   // --- End of round: tick DOT and status effects ---
   for (const c of session.combatants) {
     const meta = session.meta.get(c.id);
@@ -262,9 +274,15 @@ export function resolveIntents(
     }
   }
 
-  // --- Check win condition ---
-  const aliveTeams = session.teams.filter(t => t.combatants.length > 0);
-  const winner = aliveTeams.length === 1 ? aliveTeams[0].id : null;
+  // --- Check win condition (DOT may have ended the fight) ---
+  aliveTeams = session.teams.filter(t => t.combatants.length > 0);
+  let winner: string | null = null;
+  if (aliveTeams.length === 1) {
+    winner = aliveTeams[0].id;
+  } else if (aliveTeams.length === 0) {
+    // Same tie-break: player wins.
+    winner = 'team-a';
+  }
 
   session.turn++;
   session.phase = winner ? 'ended' : 'intent';

--- a/src/combat/resolution.ts
+++ b/src/combat/resolution.ts
@@ -244,26 +244,30 @@ export function resolveIntents(
     return { log, winner: aliveTeams[0]?.id ?? null };
   }
 
-  // --- End of round: tick DOT and status effects ---
-  for (const c of session.combatants) {
+  // --- End of round: tick DOT/status sequentially (enemies first), checking
+  // for death after each tick. First combatant to reach 0 ends the fight for
+  // their team; the other side's DOT never gets to tick.
+  let winner: string | null = null;
+  const dotOrder = [...session.combatants].sort((a, b) => Number(b.isAI) - Number(a.isAI));
+  for (const c of dotOrder) {
     const meta = session.meta.get(c.id);
     if (!meta) continue;
     const endStr = meta.state.end_round();
     c.hp = meta.state.health;
     c.resource = meta.state.resource_current;
     if (endStr) pushLog(log, endStr);
-  }
 
-  // --- Remove combatants that died to DOT ---
-  for (const team of session.teams) {
-    team.combatants = team.combatants.filter(c => {
-      if (c.hp <= 0) {
-        log.push(`${c.name} is defeated by damage over time!`);
-        session.meta.delete(c.id);
-        return false;
+    if (c.hp <= 0) {
+      const team = session.teams.find(t => t.id === c.teamId);
+      if (team) team.combatants = team.combatants.filter(x => x.id !== c.id);
+      session.meta.delete(c.id);
+      log.push(`${c.name} is defeated by damage over time!`);
+      const alive = session.teams.filter(t => t.combatants.length > 0);
+      if (alive.length === 1) {
+        winner = alive[0].id;
+        break;
       }
-      return true;
-    });
+    }
   }
 
   // --- Advance AI pattern indices ---
@@ -273,21 +277,8 @@ export function resolveIntents(
     }
   }
 
-  // --- Check win condition (DOT may have ended the fight) ---
-  aliveTeams = session.teams.filter(t => t.combatants.length > 0);
-  let winner: string | null = null;
-  let ended = false;
-  if (aliveTeams.length === 1) {
-    winner = aliveTeams[0].id;
-    ended  = true;
-  } else if (aliveTeams.length === 0) {
-    // Genuine tie: both sides hit zero in the same DOT tick. End as a draw
-    // rather than looping with no combatants.
-    ended = true;
-  }
-
   session.turn++;
-  session.phase = ended ? 'ended' : 'intent';
+  session.phase = winner ? 'ended' : 'intent';
   session.pendingIntents.clear();
 
   return { log, winner };

--- a/src/combat/resolution.ts
+++ b/src/combat/resolution.ts
@@ -120,16 +120,25 @@ export function resolveIntents(
   }
 
   // --- Action phase ---
-  for (const [id, intent] of intents) {
-    if (intent.action.type === 'pass') continue;
+  // Ordered: defend → attack → special. Within each category, player(s) before AI.
+  // After every individual action we sync HP, remove dead combatants, and end the
+  // fight if a team is wiped. This makes "Defend beats Attack" actually true
+  // (defends go up before attacks land) and matches the rock-paper-scissors the
+  // tutorial teaches.
+
+  // Resolve a single actor's intended action. Returns false if the actor's intent
+  // produces no action (pass / dead / unaffordable / unresolvable).
+  const runAction = (id: string): void => {
+    const intent = intents.get(id);
+    if (!intent || intent.action.type === 'pass') return;
 
     const actor = session.combatants.find(c => c.id === id);
-    if (!actor) continue;
+    if (!actor) return;
 
     const actorMeta = session.meta.get(id);
-    if (!actorMeta) continue;
+    if (!actorMeta) return;
 
-    if (actorMeta.state.health <= 0) continue; // killed earlier this turn, can't act
+    if (actorMeta.state.health <= 0) return; // killed earlier this turn, can't act
 
     const { weapon } = actorMeta;
     let action = null;
@@ -137,22 +146,21 @@ export function resolveIntents(
     if (intent.action.type === 'attack')  action = weapon.attack[intent.action.actionIndex]  ?? null;
     if (intent.action.type === 'special') action = weapon.special[intent.action.actionIndex] ?? null;
 
-    if (!action) continue;
+    if (!action) return;
 
     if (action.cost > 0 && action.cost > actorMeta.state.resource_current) {
       log.push(`${actor.name} cannot afford ${action.name}.`);
-      continue;
+      return;
     }
 
     if (SELF_TARGET_TYPES.has(action.type) && !action.targeted) {
       pushLog(log, resolve_action(actorMeta.state, actorMeta.state, [action]));
-      continue;
+      return;
     }
 
     if (action.aimed) {
-      // Aimed: hits the committed tile — target can dodge by moving off it
       const targetPos = intent.action.targetPos;
-      if (!targetPos) continue;
+      if (!targetPos) return;
 
       const dist = chebyshevDist(actor.pos, targetPos);
       const tileStr = `(${targetPos.x},${targetPos.y})`;
@@ -160,27 +168,27 @@ export function resolveIntents(
       if (dist > action.range) {
         const rs = actorMeta.state.apply_cost(action);
         log.push(`${actor.name}'s ${action.name}${rs} targeting ${tileStr} — out of range (dist ${dist}).`);
-        continue;
+        return;
       }
       if (action.range > 1 && !hasLineOfSight(actor.pos, targetPos, session.board)) {
         const rs = actorMeta.state.apply_cost(action);
         log.push(`${actor.name}'s ${action.name}${rs} targeting ${tileStr} — no line of sight.`);
-        continue;
+        return;
       }
 
       const occupant = session.combatants.find(c => c.pos.x === targetPos.x && c.pos.y === targetPos.y);
       if (!occupant) {
         const rs = actorMeta.state.apply_cost(action);
         log.push(`${actor.name}'s ${action.name}${rs} targeting ${tileStr} — commits to empty space, misses.`);
-        continue;
+        return;
       }
       if (occupant.teamId === actor.teamId && action.type !== ActionType.Heal && action.type !== ActionType.Buff) {
         log.push(`${actor.name}'s ${action.name} targeting ${tileStr} — friendly fire avoided.`);
-        continue;
+        return;
       }
 
       const targetMeta = session.meta.get(occupant.id);
-      if (!targetMeta) continue;
+      if (!targetMeta) return;
       pushLog(log, resolve_action(actorMeta.state, targetMeta.state, [action]));
       if (intent.action.type === 'attack' && weapon.attack_crit.length > 0 &&
           intents.get(occupant.id)?.action.type === 'special') {
@@ -188,21 +196,20 @@ export function resolveIntents(
         pushLog(log, resolve_action(actorMeta.state, targetMeta.state, weapon.attack_crit));
       }
     } else {
-      // Reactive: auto-targets the nearest enemy in range after all moves
       const enemies = session.combatants.filter(c => c.teamId !== actor.teamId);
       const inRange = enemies.filter(e => chebyshevDist(actor.pos, e.pos) <= action.range);
 
       if (inRange.length === 0) {
         const rs = actorMeta.state.apply_cost(action);
         log.push(`${actor.name}'s ${action.name}${rs} — no target in range.`);
-        continue;
+        return;
       }
 
       const target = inRange.reduce((a, b) =>
         chebyshevDist(actor.pos, a.pos) <= chebyshevDist(actor.pos, b.pos) ? a : b
       );
       const targetMeta = session.meta.get(target.id);
-      if (!targetMeta) continue;
+      if (!targetMeta) return;
       pushLog(log, resolve_action(actorMeta.state, targetMeta.state, [action]));
       if (intent.action.type === 'attack' && weapon.attack_crit.length > 0 &&
           intents.get(target.id)?.action.type === 'special') {
@@ -210,38 +217,62 @@ export function resolveIntents(
         pushLog(log, resolve_action(actorMeta.state, targetMeta.state, weapon.attack_crit));
       }
     }
-  }
+  };
 
-  // --- Sync state → combatant ---
-  for (const c of session.combatants) {
-    const meta = session.meta.get(c.id);
-    if (meta) {
-      c.hp = meta.state.health;
-      c.resource = meta.state.resource_current;
+  // Sync HP + remove dead. Returns winner team id if a team is wiped, else null.
+  const reapAndCheck = (deathKind: 'damage' | 'dot'): string | null => {
+    for (const c of session.combatants) {
+      const meta = session.meta.get(c.id);
+      if (meta) {
+        c.hp = meta.state.health;
+        c.resource = meta.state.resource_current;
+      }
+    }
+    for (const team of session.teams) {
+      team.combatants = team.combatants.filter(c => {
+        if (c.hp <= 0) {
+          log.push(deathKind === 'dot'
+            ? `${c.name} is defeated by damage over time!`
+            : `${c.name} is defeated!`);
+          session.meta.delete(c.id);
+          return false;
+        }
+        return true;
+      });
+    }
+    const alive = session.teams.filter(t => t.combatants.length > 0);
+    if (alive.length < 2) return alive[0]?.id ?? null;
+    return null;
+  };
+
+  // Action sub-phases: defend → attack → special. Player first within each.
+  // Snapshot the actor order ONCE — combatants get removed mid-phase by reapAndCheck.
+  const playerIds = snapshot.filter(c => !c.isAI).map(c => c.id);
+  const aiIds     = snapshot.filter(c =>  c.isAI).map(c => c.id);
+  const orderedIds = [...playerIds, ...aiIds];
+
+  const subPhases: Array<'defend' | 'attack' | 'special'> = ['defend', 'attack', 'special'];
+
+  let earlyWinner: string | null = null;
+
+  outer: for (const phase of subPhases) {
+    for (const id of orderedIds) {
+      const intent = intents.get(id);
+      if (!intent || intent.action.type !== phase) continue;
+      runAction(id);
+      const w = reapAndCheck('damage');
+      if (w !== null) { earlyWinner = w; break outer; }
+      // If only one team has combatants but the winner is still null (e.g. all
+      // remaining actors are on the same team and nobody died this action),
+      // reapAndCheck returns the surviving team id only when len < 2 — covered.
     }
   }
 
-  // --- Remove combatants killed by direct damage ---
-  for (const team of session.teams) {
-    team.combatants = team.combatants.filter(c => {
-      if (c.hp <= 0) {
-        log.push(`${c.name} is defeated!`);
-        session.meta.delete(c.id);
-        return false;
-      }
-      return true;
-    });
-  }
-
-  // First-to-zero loses. If direct damage already decided the fight, end here —
-  // don't tick end-of-round DOT on the survivor (their DOT damage doesn't count
-  // because the enemy already reached 0 in this phase).
-  let aliveTeams = session.teams.filter(t => t.combatants.length > 0);
-  if (aliveTeams.length < 2) {
+  if (earlyWinner !== null || session.teams.some(t => t.combatants.length === 0)) {
     session.turn++;
     session.phase = 'ended';
     session.pendingIntents.clear();
-    return { log, winner: aliveTeams[0]?.id ?? null };
+    return { log, winner: earlyWinner };
   }
 
   // --- End of round: tick DOT/status sequentially (enemies first), checking

--- a/src/combat/resolution.ts
+++ b/src/combat/resolution.ts
@@ -233,16 +233,15 @@ export function resolveIntents(
     });
   }
 
-  // If direct damage already decided the fight, end here — don't tick DOT on a
-  // corpse, and don't let a DOT-on-player kill them post-victory.
+  // First-to-zero loses. If direct damage already decided the fight, end here —
+  // don't tick end-of-round DOT on the survivor (their DOT damage doesn't count
+  // because the enemy already reached 0 in this phase).
   let aliveTeams = session.teams.filter(t => t.combatants.length > 0);
   if (aliveTeams.length < 2) {
-    // Single-player tie-break (both teams wiped in the same round): player wins.
-    const winner = aliveTeams[0]?.id ?? 'team-a';
     session.turn++;
     session.phase = 'ended';
     session.pendingIntents.clear();
-    return { log, winner };
+    return { log, winner: aliveTeams[0]?.id ?? null };
   }
 
   // --- End of round: tick DOT and status effects ---
@@ -277,15 +276,18 @@ export function resolveIntents(
   // --- Check win condition (DOT may have ended the fight) ---
   aliveTeams = session.teams.filter(t => t.combatants.length > 0);
   let winner: string | null = null;
+  let ended = false;
   if (aliveTeams.length === 1) {
     winner = aliveTeams[0].id;
+    ended  = true;
   } else if (aliveTeams.length === 0) {
-    // Same tie-break: player wins.
-    winner = 'team-a';
+    // Genuine tie: both sides hit zero in the same DOT tick. End as a draw
+    // rather than looping with no combatants.
+    ended = true;
   }
 
   session.turn++;
-  session.phase = winner ? 'ended' : 'intent';
+  session.phase = ended ? 'ended' : 'intent';
   session.pendingIntents.clear();
 
   return { log, winner };

--- a/src/economy/shop_service.ts
+++ b/src/economy/shop_service.ts
@@ -145,7 +145,7 @@ export async function buyItem(
       data: { discord_id: discordId, amount: -total, reason: 'shop_buy', note: `${quantity}× ${item.id} @ ${shopKey}` },
     });
 
-    return { success: true, message: `Bought ${quantity}× for **${total} korel**.` };
+    return { success: true, message: `Bought ${quantity}× for ${total} korel.` };
   });
 
   if (result.success) {
@@ -203,7 +203,7 @@ export async function sellItem(
     });
 
     const partialNote = actualQty < quantity ? ` (shop only had room for ${actualQty})` : '';
-    return { success: true, message: `Sold ${actualQty}× for **${total} korel**${partialNote}.` };
+    return { success: true, message: `Sold ${actualQty}× for ${total} korel${partialNote}.` };
   });
 
   if (result.success) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -147,8 +147,55 @@ const BAIT_TO_ENEMY: Record<string, EnemyKey> = {
 };
 const BAIT_ITEM_IDS = Object.keys(BAIT_TO_ENEMY);
 
-function createSession(sessionId: string, enemyKey: EnemyKey | 'tutorial_swallow', playerSprite?: string, playerName = 'Hero', weaponKey = 'branch', isTutorial = false): { session: CombatSession; lootTable: LootTable; enemyName: string } {
+// Apply per-character customizations (base/recipe bonuses, player upgrades, enchants)
+// to a freshly-loaded Weapon in place. Without this, combat rolls against the base
+// YAML field instead of the upgraded one.
+type WeaponUpgradesJson = {
+  base?:     Record<string, number | number[]>;
+  player?:   unknown;
+  enchants?: Record<string, { kind?: string; subtype?: string; type?: string; delta?: number | number[] }>;
+};
+function applyWeaponCustomizations(weapon: Weapon, weaponKey: string, upgradesJson: unknown): void {
+  if (!upgradesJson || typeof upgradesJson !== 'object') return;
+  const upgrades = upgradesJson as WeaponUpgradesJson;
+  const baseDeltas     = (upgrades.base ?? {}) as Record<string, number | number[]>;
+  const professions    = weaponUpgradeProfessions(weaponKey);
+  const playerUpgrades = normalizePlayerUpgrades(upgrades.player, professions[0]);
+  const enchants       = upgrades.enchants ?? {};
+
+  const allCategories = [weapon.defend, weapon.defend_crit, weapon.attack, weapon.attack_crit, weapon.special, weapon.special_crit];
+  for (const category of allCategories) {
+    for (const action of category) {
+      const name = action.name;
+      const a    = action as unknown as { field?: { field: number[]; length: number }; value?: number; damage_type?: string; damage_subtype?: string };
+
+      if (a.field && Array.isArray(a.field.field) && a.field.field.length > 0) {
+        const base    = a.field.field;
+        const baseB   = (baseDeltas[name] as number[] | undefined) ?? base.map(() => 0);
+        const playerB = summedFieldBonus(playerUpgrades, professions, name, base.length);
+        const enchB   = enchants[name]?.delta;
+        const enchArr = Array.isArray(enchB) ? enchB : base.map(() => 0);
+        a.field.field = base.map((v, i) => v + (baseB[i] ?? 0) + (playerB[i] ?? 0) + (enchArr[i] ?? 0));
+      } else if (typeof a.value === 'number' && a.value > 0) {
+        const baseB   = (baseDeltas[name] as number | undefined) ?? 0;
+        const playerB = summedValueBonus(playerUpgrades, professions, name);
+        const enchB   = enchants[name]?.delta;
+        const enchV   = typeof enchB === 'number' ? enchB : 0;
+        a.value = a.value + baseB + playerB + enchV;
+      }
+
+      const ench = enchants[name];
+      if (ench) {
+        if (ench.subtype) a.damage_subtype = ench.subtype;
+        if (ench.type)    a.damage_type    = ench.type;
+      }
+    }
+  }
+}
+
+function createSession(sessionId: string, enemyKey: EnemyKey | 'tutorial_swallow', playerSprite?: string, playerName = 'Hero', weaponKey = 'branch', isTutorial = false, weaponUpgrades: unknown = null): { session: CombatSession; lootTable: LootTable; enemyName: string } {
   const weapon     = Weapon.from_file(join(__dirname, `../../database/weapons/${weaponKey}.yaml`));
+  if (weaponUpgrades) applyWeaponCustomizations(weapon, weaponKey, weaponUpgrades);
   const fistsInfo = buildWeaponInfo(weapon);
   const playerHp  = weapon.hp;
   const playerState = new CombatantState(playerName, playerHp, weapon.resource_name, weapon.resource_max);
@@ -304,6 +351,14 @@ async function equippedWeaponKey(char: { equipped_weapon_id: string | null }): P
   if (!char.equipped_weapon_id) return null;
   const w = await prisma.characterWeapon.findUnique({ where: { id: char.equipped_weapon_id } });
   return w?.weapon_key ?? null;
+}
+
+// Load equipped weapon's key + upgrades (the data combat needs to roll correct fields).
+async function equippedWeaponForCombat(char: { equipped_weapon_id: string | null }): Promise<{ key: string; upgrades: unknown } | null> {
+  if (!char.equipped_weapon_id) return null;
+  const w = await prisma.characterWeapon.findUnique({ where: { id: char.equipped_weapon_id } });
+  if (!w) return null;
+  return { key: w.weapon_key, upgrades: w.upgrades };
 }
 
 // Count total bonuses on a weapon (base + player + enchants) for display as "+N"
@@ -483,8 +538,9 @@ app.post('/api/hunt/start', async (req: Request, res: Response) => {
 
   const playerSprite = char.sprite_token ? `${HOST}/sprites/${char.sprite_token}.png` : undefined;
   const sessionId    = Math.random().toString(36).slice(2, 10);
-  const weaponKey    = (await equippedWeaponKey(char)) ?? 'branch';
-  const { session: huntSession, lootTable, enemyName } = createSession(sessionId, enemyKey, playerSprite, char.name, weaponKey);
+  const equipped     = await equippedWeaponForCombat(char);
+  const weaponKey    = equipped?.key ?? 'branch';
+  const { session: huntSession, lootTable, enemyName } = createSession(sessionId, enemyKey, playerSprite, char.name, weaponKey, false, equipped?.upgrades);
   sessions.set(sessionId, huntSession);
   sessionMeta.set(sessionId, { discordUserId: discordId, isTutorial: false, lootTable, enemyName, startedAt: new Date(), rounds: [] });
 
@@ -2071,16 +2127,19 @@ io.on('connection', (socket: Socket) => {
 
     let playerName = 'Hero';
     let playerWeaponKey = 'branch';
+    let playerUpgrades: unknown = null;
     const playerSprite = session.combatants.find(c => !c.isAI)?.sprite;
     if (oldMeta) {
       const chars = await charRepo.list(oldMeta.discordUserId).catch(() => []);
       if (chars[0]) {
         playerName = chars[0].name;
-        playerWeaponKey = (await equippedWeaponKey(chars[0])) ?? 'branch';
+        const equipped = await equippedWeaponForCombat(chars[0]);
+        playerWeaponKey = equipped?.key ?? 'branch';
+        playerUpgrades  = equipped?.upgrades ?? null;
       }
     }
 
-    const { session: fresh, lootTable, enemyName } = createSession(sessionId, enemyKey, playerSprite, playerName, playerWeaponKey);
+    const { session: fresh, lootTable, enemyName } = createSession(sessionId, enemyKey, playerSprite, playerName, playerWeaponKey, oldMeta?.isTutorial ?? false, playerUpgrades);
     sessions.set(sessionId, fresh);
     if (oldMeta) {
       sessionMeta.set(sessionId, { ...oldMeta, lootTable, enemyName, startedAt: new Date(), rounds: [] });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -395,6 +395,102 @@ app.get('/api/info/enemies', (_req: Request, res: Response) => {
   res.json({ enemies });
 });
 
+// ---- Hunt ----
+
+function loadEnemySummary(enemyKey: EnemyKey): { name: string; health: number; drops: Array<{ item_id: string; name: string; type: string; field: number[] }> } | null {
+  const path = join(__dirname, `../../database/enemies/${enemyKey}.yaml`);
+  if (!fs.existsSync(path)) return null;
+  const raw = yaml.load(fs.readFileSync(path, 'utf-8')) as Record<string, unknown>;
+  const loot = (raw['Loot'] as { Items?: Array<{ id: string; type: string; Field: number[] }> } | undefined)?.Items ?? [];
+  const drops = loot.map(d => ({
+    item_id: d.id,
+    name:    ITEMS[d.id]?.name ?? d.id,
+    type:    d.type,
+    field:   d.Field ?? [],
+  }));
+  return { name: raw['Name'] as string, health: raw['Health'] as number, drops };
+}
+
+app.get('/api/hunt', async (req: Request, res: Response) => {
+  const discordId = resolveAuth(req);
+  if (!discordId) { res.status(401).json({ error: 'Unauthorized' }); return; }
+  const chars = await charRepo.list(discordId);
+  if (chars.length === 0) { res.status(400).json({ error: 'No character found' }); return; }
+  const char = chars[0];
+
+  const dbUser = await prisma.user.findUnique({ where: { discord_id: discordId } });
+  const tutorialComplete = !!dbUser?.tutorial_complete;
+
+  const baitRows = await prisma.inventoryItem.findMany({
+    where: { character_id: char.id, item_id: { in: BAIT_ITEM_IDS } },
+  });
+  const owned = baitRows.filter(r => r.quantity > 0);
+
+  const baits = owned.map(r => {
+    const enemyKey = BAIT_TO_ENEMY[r.item_id];
+    const enemy    = loadEnemySummary(enemyKey);
+    return {
+      bait_id:   r.item_id,
+      bait_name: ITEMS[r.item_id]?.name ?? r.item_id,
+      quantity:  r.quantity,
+      enemy_key:    enemyKey,
+      enemy_name:   enemy?.name ?? enemyKey,
+      enemy_health: enemy?.health ?? 0,
+      enemy_sprite: `${HOST}/sprites/${enemyKey}.png`,
+      drops:        enemy?.drops ?? [],
+    };
+  }).sort((a, b) => a.enemy_health - b.enemy_health);
+
+  res.json({ baits, tutorial_complete: tutorialComplete });
+});
+
+app.post('/api/hunt/start', async (req: Request, res: Response) => {
+  const discordId = resolveAuth(req);
+  if (!discordId) { res.status(401).json({ error: 'Unauthorized' }); return; }
+  const { bait_id } = req.body ?? {};
+  if (typeof bait_id !== 'string' || !(bait_id in BAIT_TO_ENEMY)) {
+    res.status(400).json({ error: 'Invalid bait' });
+    return;
+  }
+  const enemyKey = BAIT_TO_ENEMY[bait_id];
+
+  const chars = await charRepo.list(discordId);
+  if (chars.length === 0) { res.status(400).json({ error: 'No character found' }); return; }
+  const char = chars[0];
+
+  const dbUser = await prisma.user.findUnique({ where: { discord_id: discordId } });
+  if (!dbUser?.tutorial_complete) {
+    res.status(403).json({ error: 'Finish the tutorial first — use /battle to talk to Fendalok.' });
+    return;
+  }
+
+  const consumed = await prisma.$transaction(async tx => {
+    const inv = await tx.inventoryItem.findUnique({
+      where: { character_id_item_id: { character_id: char.id, item_id: bait_id } },
+    });
+    if (!inv || inv.quantity < 1) return false;
+    if (inv.quantity === 1) {
+      await tx.inventoryItem.delete({ where: { character_id_item_id: { character_id: char.id, item_id: bait_id } } });
+    } else {
+      await tx.inventoryItem.update({
+        where: { character_id_item_id: { character_id: char.id, item_id: bait_id } },
+        data: { quantity: { decrement: 1 } },
+      });
+    }
+    return true;
+  });
+  if (!consumed) { res.status(400).json({ error: "You don't have that bait." }); return; }
+
+  const playerSprite = char.sprite_token ? `${HOST}/sprites/${char.sprite_token}.png` : undefined;
+  const sessionId    = Math.random().toString(36).slice(2, 10);
+  const weaponKey    = (await equippedWeaponKey(char)) ?? 'branch';
+  const { session: huntSession, lootTable, enemyName } = createSession(sessionId, enemyKey, playerSprite, char.name, weaponKey);
+  sessions.set(sessionId, huntSession);
+  sessionMeta.set(sessionId, { discordUserId: discordId, isTutorial: false, lootTable, enemyName, startedAt: new Date(), rounds: [] });
+
+  res.json({ session_url: `/battle/${sessionId}` });
+});
+
 app.get('/api/character', async (req: Request, res: Response) => {
   const discordId = resolveAuth(req);
   if (!discordId) { res.status(401).json({ error: 'Unauthorized' }); return; }
@@ -2349,95 +2445,10 @@ if (discordToken) {
         await interaction.reply({ content: "You can only hunt in the forest.", flags: MessageFlags.Ephemeral });
         return;
       }
-
-      const chars = await charRepo.list(interaction.user.id);
-      if (chars.length === 0) {
-        await interaction.reply({ content: "You don't have a character yet. Use the button in welcome to get started.", flags: MessageFlags.Ephemeral });
-        return;
-      }
-
-      const dbUser = await prisma.user.findUnique({ where: { discord_id: interaction.user.id } });
-      if (!dbUser?.tutorial_complete) {
-        await interaction.reply({ content: "Talk to Fendalok first — use `/battle` to start the tutorial.", flags: MessageFlags.Ephemeral });
-        return;
-      }
-
-      const baitRows = await prisma.inventoryItem.findMany({
-        where: { character_id: chars[0].id, item_id: { in: BAIT_ITEM_IDS } },
-      });
-      const availableBait = baitRows.filter(r => r.quantity > 0);
-
-      if (availableBait.length === 0) {
-        await interaction.reply({ content: "You don't have any bait. Visit the General Store to pick some up.", flags: MessageFlags.Ephemeral });
-        return;
-      }
-
-      const baitButtons = availableBait.map(r =>
-        new ButtonBuilder()
-          .setCustomId(`Hunt_${r.item_id}`)
-          .setLabel(`${ITEMS[r.item_id]?.name ?? r.item_id} (${r.quantity})`)
-          .setStyle(ButtonStyle.Primary)
-      );
-
-      const rows: ActionRowBuilder<ButtonBuilder>[] = [];
-      for (let i = 0; i < baitButtons.length; i += 5) {
-        rows.push(new ActionRowBuilder<ButtonBuilder>().addComponents(baitButtons.slice(i, i + 5)));
-      }
-
+      const token = getOrCreateToken(interaction.user.id);
       await interaction.reply({
-        embeds: [
-          new EmbedBuilder()
-            .setColor(0x1a1a2e)
-            .setTitle('Sulkupa Forest')
-            .setDescription('The trees are dense this far out. Choose your bait and head in.'),
-        ],
-        components: rows,
+        content: `Sulkupa Forest awaits. ${HOST}/app/hunt?auth=${token}`,
         flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
-    if (interaction.isButton() && interaction.customId.startsWith('Hunt_')) {
-      const baitId = interaction.customId.replace('Hunt_', '');
-      const enemyKey = BAIT_TO_ENEMY[baitId];
-      if (!enemyKey) return;
-
-      const chars = await charRepo.list(interaction.user.id);
-      if (chars.length === 0) return;
-      const char = chars[0];
-
-      const consumed = await prisma.$transaction(async tx => {
-        const inv = await tx.inventoryItem.findUnique({
-          where: { character_id_item_id: { character_id: char.id, item_id: baitId } },
-        });
-        if (!inv || inv.quantity < 1) return false;
-        if (inv.quantity === 1) {
-          await tx.inventoryItem.delete({ where: { character_id_item_id: { character_id: char.id, item_id: baitId } } });
-        } else {
-          await tx.inventoryItem.update({
-            where: { character_id_item_id: { character_id: char.id, item_id: baitId } },
-            data: { quantity: { decrement: 1 } },
-          });
-        }
-        return true;
-      });
-
-      if (!consumed) {
-        await interaction.update({ content: "You don't have that bait anymore.", embeds: [], components: [] });
-        return;
-      }
-
-      const playerSprite = char.sprite_token ? `${HOST}/sprites/${char.sprite_token}.png` : undefined;
-      const sessionId = Math.random().toString(36).slice(2, 10);
-      const charWeaponKey = (await equippedWeaponKey(char)) ?? 'branch';
-      const { session: huntSession, lootTable, enemyName } = createSession(sessionId, enemyKey, playerSprite, char.name, charWeaponKey);
-      sessions.set(sessionId, huntSession);
-      sessionMeta.set(sessionId, { discordUserId: interaction.user.id, isTutorial: false, lootTable, enemyName, startedAt: new Date(), rounds: [] });
-
-      await interaction.update({
-        content: `**Into the forest!**\n${HOST}/battle/${sessionId}`,
-        embeds: [],
-        components: [],
       });
       return;
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1314,10 +1314,14 @@ app.get('/api/craft', async (req: Request, res: Response) => {
     levelMet:       (profLevels[r.profession] ?? 0) >= r.required_level,
     ingredientsMet: r.ingredients.every(ingredientMet),
     available:      (profLevels[r.profession] ?? 0) >= r.required_level && r.ingredients.every(ingredientMet),
-    ingredients: r.ingredients.map(i => ({
-      ...i,
-      name: i.item_id ? (ITEMS[i.item_id]?.name ?? i.item_id) : (i.weapon_id ?? ''),
-    })),
+    ingredients: r.ingredients.map(i => {
+      if (i.item_id) return { ...i, name: ITEMS[i.item_id]?.name ?? i.item_id };
+      if (i.weapon_id) {
+        const raw = loadWeaponYaml(i.weapon_id, __dirname) as Record<string, unknown> | null;
+        return { ...i, name: (raw?.['Name'] as string | undefined) ?? i.weapon_id };
+      }
+      return { ...i, name: '' };
+    }),
   }));
 
   res.json({
@@ -1514,7 +1518,11 @@ app.get('/api/upgrade', async (req: Request, res: Response) => {
       const profUsed = totalUpgradesUsed(profDeltas, fieldLens);
       const budget   = profBudgets[i];
       const atCap    = profUsed >= budget || weaponAtCap;
-      return { profession: prof, used: profUsed, budget, at_cap: atCap, next_cost: atCap ? null : upgradeCost(weaponTotal + 1, prof) };
+      const cost = atCap ? null : upgradeCost(weaponTotal + 1, prof);
+      return {
+        profession: prof, used: profUsed, budget, at_cap: atCap,
+        next_cost: cost ? { ...cost, material_name: ITEMS[cost.material]?.name ?? cost.material } : null,
+      };
     });
 
     const actions = actionsWithCategories(raw).map(({ category, action: a }) => {
@@ -1628,7 +1636,7 @@ app.post('/api/upgrade/:weaponId', async (req: Request, res: Response) => {
       where: { character_id_item_id: { character_id: char.id, item_id: cost.material } },
     });
     if ((invRow?.quantity ?? 0) < cost.quantity) {
-      return { success: false, message: `Need ${cost.quantity} ${cost.material} (have ${invRow?.quantity ?? 0}).` };
+      return { success: false, message: `Need ${cost.quantity} ${ITEMS[cost.material]?.name ?? cost.material} (have ${invRow?.quantity ?? 0}).` };
     }
 
     if (invRow!.quantity === cost.quantity) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1610,7 +1610,7 @@ app.post('/api/upgrade/:weaponId', async (req: Request, res: Response) => {
     const budget     = budgetForLevel(profLevelOf(profession));
     const weaponCap  = weaponUpgradeCap(validProfessions.map(p => budgetForLevel(profLevelOf(p))));
 
-    const upgrades       = (weaponRow.upgrades ?? {}) as { base?: Record<string, unknown>; player?: unknown };
+    const upgrades       = (weaponRow.upgrades ?? {}) as { base?: Record<string, unknown>; player?: unknown; enchants?: Record<string, unknown> };
     const playerUpgrades = normalizePlayerUpgrades(upgrades.player, validProfessions[0]);
     const profDeltas: Record<string, number | number[]> = { ...(playerUpgrades[profession] ?? {}) };
     const profUsed    = totalUpgradesUsed(profDeltas, fieldLens);
@@ -1650,7 +1650,7 @@ app.post('/api/upgrade/:weaponId', async (req: Request, res: Response) => {
     const updatedPlayer = { ...playerUpgrades, [profession]: profDeltas };
     await tx.characterWeapon.update({
       where: { id: weaponId },
-      data: { upgrades: { base: upgrades.base ?? {}, player: updatedPlayer } as Prisma.InputJsonValue },
+      data: { upgrades: { ...upgrades, base: upgrades.base ?? {}, player: updatedPlayer } as Prisma.InputJsonValue },
     });
 
     await tx.eventLog.create({ data: {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -498,10 +498,11 @@ app.get('/api/character', async (req: Request, res: Response) => {
   if (chars.length === 0) { res.status(400).json({ error: 'No character found' }); return; }
   const char = chars[0];
 
-  const weapons = await prisma.characterWeapon.findMany({
-    where: { character_id: char.id },
-    orderBy: { created_at: 'asc' },
-  });
+  const [weapons, dbUser, profRows] = await Promise.all([
+    prisma.characterWeapon.findMany({ where: { character_id: char.id }, orderBy: { created_at: 'asc' } }),
+    prisma.user.findUnique({ where: { discord_id: discordId } }),
+    prisma.characterProfession.findMany({ where: { character_id: char.id } }),
+  ]);
   const weaponList = weapons.map(w => {
     const raw = loadWeaponYaml(w.weapon_key, __dirname) as Record<string, unknown> | null;
     return {
@@ -516,6 +517,10 @@ app.get('/api/character', async (req: Request, res: Response) => {
     };
   }).sort((a, b) => Number(b.equipped) - Number(a.equipped) || a.name.localeCompare(b.name));
 
+  const profLevels: Record<string, number> = {};
+  for (const p of profRows) profLevels[p.profession] = p.level;
+  const combined = profRows.reduce((sum, p) => sum + p.level, 0);
+
   res.json({
     id:           char.id,
     name:         char.name,
@@ -527,6 +532,15 @@ app.get('/api/character', async (req: Request, res: Response) => {
     max_health:   char.max_health,
     equipped_weapon_id: char.equipped_weapon_id,
     weapons:      weaponList,
+    korel:        dbUser?.korel ?? 0,
+    professions: Object.fromEntries(
+      PROFESSIONS.map(p => [p, {
+        label:    PROFESSION_NAMES[p],
+        level:    profLevels[p] ?? 0,
+        maxLevel: PROFESSION_MAX_LEVEL,
+        nextCost: (profLevels[p] ?? 0) < PROFESSION_MAX_LEVEL ? levelCost(combined) : null,
+      }])
+    ),
   });
 });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2530,7 +2530,7 @@ if (discordToken) {
           new ActionRowBuilder<ButtonBuilder>().addComponents(
             new ButtonBuilder()
               .setLabel('Follow Fendalok')
-              .setURL(`${HOST}/battle/${sessionId}`)
+              .setURL(`${HOST}/battle/${sessionId}?auth=${getOrCreateToken(interaction.user.id)}`)
               .setStyle(ButtonStyle.Link)
           ),
         ],


### PR DESCRIPTION
## Summary

0.1.1 release — hunting moves into the web app, combat resolution gets per-phase death checks, plus combat-log filtering, status badges, and assorted UX/naming polish.

See `docs/CHANGELOG.md` for the full entry. Highlights:

- **Hunt → Web App** — bait picker, palette, layout header, Return-to-Town all on the SPA
- **Combat resolution** — sub-phases run defend → attack → special, player before AI, with death checks between each action; sequential DOT with checks per tick; first-to-zero loses
- **Combat UI** — log line classification + filter chips, action category tags, status badges (block/shield/DOT/buff/debuff/reflect), own-tile target-click fix
- **Fixes** — weapon upgrades now apply in combat (Sebastian wand bug), upgrade endpoint preserves enchants, stock shows XXX/YYY, crafting locked-text contrast
- **Infra** — deploy scripts `unset DATABASE_URL` to stop the webhook-env leak

## Test plan

- [ ] Dev deploy clean
- [ ] `/hunt` opens the web app hunt view; start a battle
- [ ] Battle screen renders with new palette + layout header
- [ ] Combat log filter chips toggle correctly
- [ ] Status badges appear/decay on combatant cards
- [ ] Self-targeting Heal/Buff can pick own tile
- [ ] Upgrade an action; in-combat rolls use the upgraded Field
- [ ] Apply enchant after an upgrade; enchant persists
- [ ] Shop at max stock still shows item + owned quantity

🤖 Generated with [Claude Code](https://claude.com/claude-code)