### PR TITLE
Hotfix: version-stamp HTML asset URLs

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -266,8 +266,28 @@ function createSession(sessionId: string, enemyKey: EnemyKey | 'tutorial_swallow
 app.use(express.static(join(__dirname, '../../public')));
 app.use(express.json());
 
+// Read the bot version once at startup. Used to stamp asset URLs in HTML so
+// every deploy invalidates browser + Cloudflare caches without relying on a
+// per-URL purge — the URL is literally different so caches can't get stuck.
+const APP_VERSION = (() => {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(join(__dirname, '../../package.json'), 'utf8'));
+    return String(pkg.version ?? 'dev');
+  } catch (_) { return 'dev'; }
+})();
+
+function sendVersionedHtml(res: Response, file: 'index.html' | 'app.html'): void {
+  const raw = fs.readFileSync(join(__dirname, '../../public', file), 'utf8');
+  // Append ?v=VERSION to every same-origin .js/.css asset URL (skip ones
+  // that already have a query string). HTML itself is sent no-cache so the
+  // browser always picks up the latest version stamp on every navigation.
+  const stamped = raw.replace(/(src|href)="(\/[^"?]+\.(?:js|css))"/g, `$1="$2?v=${APP_VERSION}"`);
+  res.setHeader('Cache-Control', 'no-cache');
+  res.type('html').send(stamped);
+}
+
 app.get('/battle/:sessionId', (_req: Request, res: Response) => {
-  res.sendFile(join(__dirname, '../../public/index.html'));
+  sendVersionedHtml(res, 'index.html');
 });
 
 app.get('/trade/:tradeId', (_req: Request, res: Response) => {
@@ -275,7 +295,7 @@ app.get('/trade/:tradeId', (_req: Request, res: Response) => {
 });
 
 app.get(/^\/app(\/.*)?$/, (_req: Request, res: Response) => {
-  res.sendFile(join(__dirname, '../../public/app.html'));
+  sendVersionedHtml(res, 'app.html');
 });
 
 // Redirect legacy standalone URLs to the /app equivalent (preserve ?auth=).


### PR DESCRIPTION
## Summary

Cherry-pick of \`1a7bad4\` from dev. Fixes the "Unknown view: hunt" failure that bit lcePops on the 0.1.1 rollout — his CF edge had cached a 404 for \`/views/hunt.js\` and even after multiple purges + incognito + Chrome the stale entry wouldn't clear.

\`/app\` and \`/battle/:id\` now render their HTML at request time with \`?v=\${pkg.version}\` appended to every same-origin \`.js\`/\`.css\` URL, and the HTML response goes out as \`Cache-Control: no-cache\`. Every deploy bumps the stamp → fresh URL → CF/browser must fetch from origin → can't serve stale.

The CF auto-purge wired into deploy-prod.sh stays as a backstop (on dev, not yet on main), but the version stamp is what actually makes this class of bug impossible.

## Test plan

- [ ] Verified on dev: \`/app/*\` HTML has \`?v=0.1.1\` on every script/link, Cache-Control: no-cache on the HTML response
- [ ] After merge, lcePops's next page load picks up fresh content without him doing anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)