### PR TITLE
0.1.3 patch: no diagonal corner-cutting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ picks up a handful of polish items.
 ### Fixes
 - **Shop transaction left the cart broken** — `clearCart` was missing the `buyWeapons: {}` initializer, so after a checkout `cart.buyWeapons` became undefined and the next render threw, silently aborting the `await mountLayout()` that follows. Net effect: header korel didn't update + the shop UI deadlocked until refresh. One-line fix.
 - **Near-invisible grey on dark background** — sweep replaced `--text-vdim` with `--text-faint` on `.shop-item-name.dim`, `.shop-empty`, `.empty`, `.cannot-upg`, `.prof-none`. Item names on full-shop sell rows are legible again.
+- **Diagonal corner-cutting through obstacles** — combatants (and aimed attacks) could squeeze between two diagonally-touching obstacles. Now blocks the diagonal step when both orthogonal neighbors are obstacles. Applied to server movement BFS, server LOS, the matching client copies, and the hunt-obstacle reachability re-roll check.
 
 ---
 

--- a/public/game.js
+++ b/public/game.js
@@ -150,6 +150,11 @@ function computeReachable(combatant) {
         const sk = `${k}:${newParity}`;
         if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
         if (obstacleSet.has(k)) continue;
+        // No diagonal corner-cutting (mirrors server-side movement BFS).
+        if (isDiag) {
+          const ka = `${pos.x},${ny}`, kb = `${nx},${pos.y}`;
+          if (obstacleSet.has(ka) && obstacleSet.has(kb)) continue;
+        }
         if (newCost > range) continue;
         if ((stateCosts.get(sk) ?? Infinity) <= newCost) continue;
         if (occupiedSet.has(k)) continue;
@@ -192,10 +197,21 @@ function hasLineOfSight(from, to, board) {
   const dx = Math.abs(x1 - x0), dy = Math.abs(y1 - y0);
   const sx = x0 < x1 ? 1 : -1, sy = y0 < y1 ? 1 : -1;
   let err = dx - dy;
+  const W = board.width, H = board.height;
+  const inB = (x, y) => x >= 0 && x < W && y >= 0 && y < H;
   while (!(x0 === x1 && y0 === y1)) {
     const e2 = 2 * err;
-    if (e2 > -dy) { err -= dy; x0 += sx; }
-    if (e2 <  dx) { err += dx; y0 += sy; }
+    const advX = e2 > -dy;
+    const advY = e2 <  dx;
+    // Diagonal step — sight can't squeeze between two corner obstacles
+    // (matches the no-corner-cut movement rule).
+    if (advX && advY) {
+      const ax = x0 + sx, ay = y0;
+      const bx = x0, by = y0 + sy;
+      if (inB(ax, ay) && inB(bx, by) && obstacleSet.has(`${ax},${ay}`) && obstacleSet.has(`${bx},${by}`)) return false;
+    }
+    if (advX) { err -= dy; x0 += sx; }
+    if (advY) { err += dx; y0 += sy; }
     if (x0 === x1 && y0 === y1) break;
     if (obstacleSet.has(`${x0},${y0}`)) return false;
   }

--- a/src/combat/los.ts
+++ b/src/combat/los.ts
@@ -9,8 +9,19 @@ export function hasLineOfSight(from: Pos, to: Pos, board: Board): boolean {
 
   while (x !== to.x || y !== to.y) {
     const e2 = 2 * err;
-    if (e2 > -dy) { err -= dy; x += sx; }
-    if (e2 < dx) { err += dx; y += sy; }
+    const advX = e2 > -dy;
+    const advY = e2 < dx;
+    // Diagonal step — sight can't squeeze between two corner obstacles
+    // (matches the movement-side no-corner-cut rule).
+    if (advX && advY) {
+      const a = { x: x + sx, y };
+      const b = { x, y: y + sy };
+      if (board.inBounds(a) && board.inBounds(b) && board.isBlocked(a) && board.isBlocked(b)) {
+        return false;
+      }
+    }
+    if (advX) { err -= dy; x += sx; }
+    if (advY) { err += dx; y += sy; }
     if (x === to.x && y === to.y) break;
     if (board.isBlocked({ x, y })) return false;
   }

--- a/src/combat/movement.ts
+++ b/src/combat/movement.ts
@@ -26,6 +26,14 @@ export function reachableTiles(
       if (newCost > range) continue;
       if (!board.inBounds(n)) continue;
       if (board.isBlocked(n)) continue;
+      // No diagonal corner-cutting: if both orthogonal neighbors that the
+      // diagonal step "squeezes between" are blocked, the diagonal is
+      // blocked too. Out-of-bounds doesn't count (board edge isn't a wall).
+      if (isDiag) {
+        const a = { x: pos.x, y: n.y };
+        const b = { x: n.x, y: pos.y };
+        if (board.inBounds(a) && board.inBounds(b) && board.isBlocked(a) && board.isBlocked(b)) continue;
+      }
       if ((costs.get(sk) ?? Infinity) <= newCost) continue;
       if (occupied.has(k)) continue;
       costs.set(sk, newCost);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -262,6 +262,12 @@ function pathExists(width: number, height: number, blocked: Set<string>, start: 
         if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
         const k = `${nx},${ny}`;
         if (seen.has(k) || blocked.has(k)) continue;
+        // No diagonal corner-cutting (matches the in-game movement rule —
+        // a layout that walls the player off via this rule needs re-rolling).
+        if (dx !== 0 && dy !== 0) {
+          const ka = `${p.x},${ny}`, kb = `${nx},${p.y}`;
+          if (blocked.has(ka) && blocked.has(kb)) continue;
+        }
         seen.add(k);
         q.push({ x: nx, y: ny });
       }


### PR DESCRIPTION
## Summary

Movement + LOS fix that landed after the initial 0.1.3 merge: combatants and aimed attacks could squeeze diagonally through a corner gap between two obstacles. Now blocks the diagonal step when both orthogonal neighbors are obstacles.

Applied in all five places that touch movement / sight:
- \`src/combat/movement.ts\` (server BFS — AI + intent validation)
- \`src/combat/los.ts\` (aimed-attack LOS)
- \`public/game.js computeReachable\` (client reachable highlights)
- \`public/game.js hasLineOfSight\` (client targetable highlights)
- \`src/server/index.ts pathExists\` (hunt obstacle reachability re-roll)

Version stays at 0.1.3; changelog entry appended under the existing Fixes section. Auto-announce won't refire.

## Test plan

- [ ] Two obstacles set at (4,1) and (5,2); combatant at (5,1) cannot move to (4,2)
- [ ] Aimed attacks respect the same rule
- [ ] Hunt boards that would only be "passable" through a corner squeeze get re-rolled

🤖 Generated with [Claude Code](https://claude.com/claude-code)