### PR TITLE
0.1.4 — golnosar, mobile, keyboard, ALL buttons, economy tuning

### DIFF
--- a/database/enemies/golnosar.yaml
+++ b/database/enemies/golnosar.yaml
@@ -1,5 +1,5 @@
 Name: Golnosar
-Health: 150
+Health: 110
 Level: 4
 Loot:
   Items:

--- a/database/enemies/golnosar.yaml
+++ b/database/enemies/golnosar.yaml
@@ -1,0 +1,90 @@
+Name: Golnosar
+Health: 150
+Level: 4
+Loot:
+  Items:
+    - id: thuvel
+      type: material
+      Field: [0, 1, 1, 2, 2]
+    - id: hiruos
+      type: material
+      Field: [0, 0, 1, 1, 2]
+    - id: crude_talamite
+      type: material
+      Field: [0, 0, 0, 1, 1, 1, 1]
+    - id: sulwood
+      type: material
+      Field: [0, 0, 1, 1, 1, 1, 1]
+    - id: bottle_of_tar
+      type: valuable
+      Field: [0, 1, 1, 2, 3, 3]
+    - id: diamond
+      type: valuable
+      Field: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+Pattern:
+  - [1, 0]   # Defend: Tar Drink
+  - [2, 0]   # Attack: Tar Shot
+  - [2, 0]   # Attack: Tar Shot
+  - [2, 0]   # Attack: Tar Shot
+  - [2, 0]   # Attack: Tar Shot
+  - [3, 0]   # Special: Fistar
+  - [2, 0]   # Attack: Tar Shot
+  - [2, 0]   # Attack: Tar Shot
+Image: ""
+
+Weapon:
+  Name: Living Tar
+  Description: A golnosar, dripping with the black resin that fuels it.
+  Resource:
+    Name: Tar
+    Max: 10
+
+  Defend:
+    - Name: Tar Drink
+      Type: 2
+      Type_Name: Block
+      Damage_Type: Arcane
+      Damage_Subtype: Plant
+      Value: 10
+      Cost: -10
+      Action_String: "<User> drinks deeply from its own tar pool, blocking 10 damage and restoring 10 Tar."
+
+  Defend Crit: []
+
+  Attack:
+    - Name: Tar Shot
+      Type: 1
+      Type_Name: Strike
+      Damage_Type: Physical
+      Damage_Subtype: Blunt
+      Field: [0, 1, 2, 5, 6, 7, 8]
+      Cost: 1
+      Aimed: false
+      Range: 3
+      Action_String: "<User> spits a thick wad of tar at <Target> for <Damage> damage."
+
+  Attack Crit:
+    - Name: Blind
+      Type: 4
+      Type_Name: DOT
+      Damage_Type: Physical
+      Damage_Subtype: Blunt
+      Field: [10]
+      Rounds: 3
+      Range: 2
+      Action_String: "<User> blinds <Target> with a faceful of tar, dealing <Damage> damage per round for 3 rounds."
+
+  Special:
+    - Name: Fistar
+      Type: 4
+      Type_Name: DOT
+      Damage_Type: Arcane
+      Damage_Subtype: Fire
+      Field: [5, 8, 10, 14]
+      Rounds: 5
+      Cost: 4
+      Aimed: true
+      Range: 4
+      Action_String: "<User> ignites a fistar above <Target>, burning for <Damage> damage per round for 5 rounds."
+
+  Special Crit: []

--- a/database/enemies/golnosar.yaml
+++ b/database/enemies/golnosar.yaml
@@ -18,7 +18,7 @@ Loot:
     - id: bottle_of_tar
       type: valuable
       Field: [0, 1, 1, 2, 3, 3]
-    - id: diamond
+    - id: lifgem
       type: valuable
       Field: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
 Pattern:

--- a/database/enemies/melbear.yaml
+++ b/database/enemies/melbear.yaml
@@ -12,7 +12,7 @@ Loot:
     - id: sulwood
       type: material
       Field: [0, 0, 0, 1, 1, 2]
-    - id: bear_teeth
+    - id: melstone
       type: valuable
       Field: [0, 1, 1, 1, 1, 2, 2, 2]
     - id: venison

--- a/database/lore/world.md
+++ b/database/lore/world.md
@@ -12,7 +12,7 @@ The town has become an outpost for those looking to make a name for themselves. 
 
 ## The Chaevul Empire
 
-The empire is ruled by **Emperor Gustavus**. His likeness appears as the king card in standard playing decks across the continent — the most common way most subjects encounter him in their daily lives.
+The empire is ruled by **Emperor Gustavus**. His face is stamped on every korel coin — the most common way most subjects encounter him in their daily lives. He also appears as the king card in standard playing decks across the continent.
 
 (More to be detailed as the world expands.)
 

--- a/database/lore/world.md
+++ b/database/lore/world.md
@@ -10,6 +10,14 @@ The town has become an outpost for those looking to make a name for themselves. 
 
 ---
 
+## The Chaevul Empire
+
+The empire is ruled by **Emperor Gustavus**. His likeness appears as the king card in standard playing decks across the continent — the most common way most subjects encounter him in their daily lives.
+
+(More to be detailed as the world expands.)
+
+---
+
 ## Sidaev
 
 **Sidaev** is a force woven through the living world — present in creatures, plants, and people in varying concentrations. Its nature is contested.

--- a/database/recipes/enchanter.yaml
+++ b/database/recipes/enchanter.yaml
@@ -80,6 +80,8 @@ recipes:
     ingredients:
       - item_id: hiruos
         quantity: 5
+      - item_id: card_deck
+        quantity: 1
     output:
       type: weapon
       id: deck_of_cards

--- a/database/recipes/enchanter.yaml
+++ b/database/recipes/enchanter.yaml
@@ -175,6 +175,8 @@ recipes:
     ingredients:
       - item_id: nodol
         quantity: 4
+      - item_id: card_deck
+        quantity: 1
     output:
       type: weapon
       id: deck_of_cards

--- a/database/shops/blacksmith.yaml
+++ b/database/shops/blacksmith.yaml
@@ -10,7 +10,7 @@ Items:
     Base_Sell: 20
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 400
+    Volume_Sensitivity: 50
     Transaction_Threshold: 15
     Stock_Max: 500
     Stock_Influence: 0.2
@@ -22,7 +22,7 @@ Items:
     Base_Sell: 40
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 100
+    Volume_Sensitivity: 20
     Transaction_Threshold: 10
     Stock_Max: 200
     Stock_Influence: 0.2
@@ -33,7 +33,7 @@ Items:
     Base_Sell: 80
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 50
+    Volume_Sensitivity: 10
     Transaction_Threshold: 6
     Stock_Max: 80
     Stock_Influence: 0.25
@@ -45,7 +45,7 @@ Items:
     Base_Sell: 100
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -56,7 +56,7 @@ Items:
     Base_Sell: 180
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -67,7 +67,7 @@ Items:
     Base_Sell: 200
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -78,7 +78,7 @@ Items:
     Base_Sell: 200
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -89,7 +89,7 @@ Items:
     Base_Sell: 200
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -101,7 +101,7 @@ Items:
     Base_Sell: 120
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 8
     Transaction_Threshold: 8
     Stock_Max: 50
     Stock_Influence: 0.2
@@ -112,7 +112,7 @@ Items:
     Base_Sell: 120
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 8
     Transaction_Threshold: 8
     Stock_Max: 50
     Stock_Influence: 0.2
@@ -123,7 +123,7 @@ Items:
     Base_Sell: 120
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 8
     Transaction_Threshold: 8
     Stock_Max: 50
     Stock_Influence: 0.2
@@ -134,7 +134,7 @@ Items:
     Base_Sell: 80
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 8
     Transaction_Threshold: 8
     Stock_Max: 50
     Stock_Influence: 0.2
@@ -146,7 +146,7 @@ Items:
     Base_Sell: 240
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 20
+    Volume_Sensitivity: 5
     Transaction_Threshold: 5
     Stock_Max: 25
     Stock_Influence: 0.25
@@ -157,7 +157,7 @@ Items:
     Base_Sell: 240
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 20
+    Volume_Sensitivity: 5
     Transaction_Threshold: 5
     Stock_Max: 25
     Stock_Influence: 0.25
@@ -168,7 +168,7 @@ Items:
     Base_Sell: 240
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 20
+    Volume_Sensitivity: 5
     Transaction_Threshold: 5
     Stock_Max: 25
     Stock_Influence: 0.25
@@ -179,7 +179,7 @@ Items:
     Base_Sell: 160
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 20
+    Volume_Sensitivity: 5
     Transaction_Threshold: 5
     Stock_Max: 25
     Stock_Influence: 0.25
@@ -191,7 +191,7 @@ Items:
     Base_Sell: 40
     R: 3.0
     R_Max: 3.99
-    Volume_Sensitivity: 200
+    Volume_Sensitivity: 30
     Transaction_Threshold: 12
     Stock_Max: 300
     Stock_Influence: 0.15

--- a/database/shops/blacksmith.yaml
+++ b/database/shops/blacksmith.yaml
@@ -8,8 +8,8 @@ Items:
   - id: crude_talamite
     Base_Buy: 100
     Base_Sell: 20
-    R: 1.8
-    R_Max: 3.0
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 400
     Transaction_Threshold: 15
     Stock_Max: 500
@@ -21,7 +21,7 @@ Items:
     Base_Buy: 200
     Base_Sell: 40
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 100
     Transaction_Threshold: 10
     Stock_Max: 200
@@ -31,8 +31,8 @@ Items:
   - id: alloy
     Base_Buy: 400
     Base_Sell: 80
-    R: 2.2
-    R_Max: 3.2
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 50
     Transaction_Threshold: 6
     Stock_Max: 80
@@ -44,7 +44,7 @@ Items:
     Base_Buy: 500
     Base_Sell: 100
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -55,7 +55,7 @@ Items:
     Base_Buy: 900
     Base_Sell: 180
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -66,7 +66,7 @@ Items:
     Base_Buy: 1000
     Base_Sell: 200
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -77,7 +77,7 @@ Items:
     Base_Buy: 1000
     Base_Sell: 200
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -88,7 +88,7 @@ Items:
     Base_Buy: 1000
     Base_Sell: 200
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -100,7 +100,7 @@ Items:
     Base_Buy: 600
     Base_Sell: 120
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 40
     Transaction_Threshold: 8
     Stock_Max: 50
@@ -111,7 +111,7 @@ Items:
     Base_Buy: 600
     Base_Sell: 120
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 40
     Transaction_Threshold: 8
     Stock_Max: 50
@@ -122,7 +122,7 @@ Items:
     Base_Buy: 600
     Base_Sell: 120
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 40
     Transaction_Threshold: 8
     Stock_Max: 50
@@ -133,7 +133,7 @@ Items:
     Base_Buy: 400
     Base_Sell: 80
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 40
     Transaction_Threshold: 8
     Stock_Max: 50
@@ -144,8 +144,8 @@ Items:
   - id: sword_blade_alloy
     Base_Buy: 1200
     Base_Sell: 240
-    R: 2.2
-    R_Max: 3.3
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 20
     Transaction_Threshold: 5
     Stock_Max: 25
@@ -155,8 +155,8 @@ Items:
   - id: axe_head_alloy
     Base_Buy: 1200
     Base_Sell: 240
-    R: 2.2
-    R_Max: 3.3
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 20
     Transaction_Threshold: 5
     Stock_Max: 25
@@ -166,8 +166,8 @@ Items:
   - id: shovel_head_alloy
     Base_Buy: 1200
     Base_Sell: 240
-    R: 2.2
-    R_Max: 3.3
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 20
     Transaction_Threshold: 5
     Stock_Max: 25
@@ -177,8 +177,8 @@ Items:
   - id: wand_base_alloy
     Base_Buy: 800
     Base_Sell: 160
-    R: 2.2
-    R_Max: 3.3
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 20
     Transaction_Threshold: 5
     Stock_Max: 25
@@ -189,8 +189,8 @@ Items:
   - id: bear_teeth
     Base_Buy: 120
     Base_Sell: 40
-    R: 1.8
-    R_Max: 2.8
+    R: 3.0
+    R_Max: 3.99
     Volume_Sensitivity: 200
     Transaction_Threshold: 12
     Stock_Max: 300

--- a/database/shops/blacksmith.yaml
+++ b/database/shops/blacksmith.yaml
@@ -186,7 +186,7 @@ Items:
     Restock_Field: [1, 2, 2, 3, 0]
 
   # Valuables
-  - id: bear_teeth
+  - id: melstone
     Base_Buy: 120
     Base_Sell: 40
     R: 3.0

--- a/database/shops/enchanting_shop.yaml
+++ b/database/shops/enchanting_shop.yaml
@@ -117,13 +117,13 @@ Items:
     Restock_Field: [1, 2, 2, 3, 0]
 
   # Valuables
-  - id: diamond
-    Base_Buy: 2000
-    Base_Sell: 1000
+  - id: lifgem
+    Base_Buy: 800
+    Base_Sell: 400
     R: 3.0
     R_Max: 3.99
-    Volume_Sensitivity: 3
-    Transaction_Threshold: 3
-    Stock_Max: 10
-    Stock_Influence: 0.4
-    Restock_Field: [0, 1, 1, 2, 0]
+    Volume_Sensitivity: 30
+    Transaction_Threshold: 5
+    Stock_Max: 50
+    Stock_Influence: 0.3
+    Restock_Field: [1, 2, 2, 3, 0]

--- a/database/shops/enchanting_shop.yaml
+++ b/database/shops/enchanting_shop.yaml
@@ -9,7 +9,7 @@ Items:
     Base_Sell: 20
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 400
+    Volume_Sensitivity: 50
     Transaction_Threshold: 15
     Stock_Max: 500
     Stock_Influence: 0.2
@@ -21,7 +21,7 @@ Items:
     Base_Sell: 40
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 100
+    Volume_Sensitivity: 20
     Transaction_Threshold: 10
     Stock_Max: 200
     Stock_Influence: 0.2
@@ -32,7 +32,7 @@ Items:
     Base_Sell: 80
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 50
+    Volume_Sensitivity: 10
     Transaction_Threshold: 6
     Stock_Max: 80
     Stock_Influence: 0.25
@@ -43,7 +43,7 @@ Items:
     Base_Sell: 25
     R: 3.0
     R_Max: 3.99
-    Volume_Sensitivity: 400
+    Volume_Sensitivity: 80
     Transaction_Threshold: 15
     Stock_Max: 500
     Stock_Influence: 0.15
@@ -55,7 +55,7 @@ Items:
     Base_Sell: 100
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -66,7 +66,7 @@ Items:
     Base_Sell: 200
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -77,7 +77,7 @@ Items:
     Base_Sell: 200
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -88,7 +88,7 @@ Items:
     Base_Sell: 200
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -99,7 +99,7 @@ Items:
     Base_Sell: 200
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -110,7 +110,7 @@ Items:
     Base_Sell: 200
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3

--- a/database/shops/enchanting_shop.yaml
+++ b/database/shops/enchanting_shop.yaml
@@ -7,8 +7,8 @@ Items:
   - id: thuvel
     Base_Buy: 100
     Base_Sell: 20
-    R: 1.8
-    R_Max: 3.0
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 400
     Transaction_Threshold: 15
     Stock_Max: 500
@@ -20,7 +20,7 @@ Items:
     Base_Buy: 200
     Base_Sell: 40
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 100
     Transaction_Threshold: 10
     Stock_Max: 200
@@ -30,8 +30,8 @@ Items:
   - id: nodol
     Base_Buy: 400
     Base_Sell: 80
-    R: 2.2
-    R_Max: 3.2
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 50
     Transaction_Threshold: 6
     Stock_Max: 80
@@ -41,8 +41,8 @@ Items:
   - id: crystal_tooth
     Base_Buy: 100
     Base_Sell: 25
-    R: 1.8
-    R_Max: 2.8
+    R: 3.0
+    R_Max: 3.99
     Volume_Sensitivity: 400
     Transaction_Threshold: 15
     Stock_Max: 500
@@ -54,7 +54,7 @@ Items:
     Base_Buy: 500
     Base_Sell: 100
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -65,7 +65,7 @@ Items:
     Base_Buy: 1000
     Base_Sell: 200
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -76,7 +76,7 @@ Items:
     Base_Buy: 1000
     Base_Sell: 200
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -87,7 +87,7 @@ Items:
     Base_Buy: 1000
     Base_Sell: 200
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -98,7 +98,7 @@ Items:
     Base_Buy: 1000
     Base_Sell: 200
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -109,7 +109,7 @@ Items:
     Base_Buy: 1000
     Base_Sell: 200
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20

--- a/database/shops/enchanting_shop.yaml
+++ b/database/shops/enchanting_shop.yaml
@@ -115,3 +115,15 @@ Items:
     Stock_Max: 20
     Stock_Influence: 0.3
     Restock_Field: [1, 2, 2, 3, 0]
+
+  # Valuables
+  - id: diamond
+    Base_Buy: 2000
+    Base_Sell: 1000
+    R: 3.0
+    R_Max: 3.99
+    Volume_Sensitivity: 3
+    Transaction_Threshold: 3
+    Stock_Max: 10
+    Stock_Influence: 0.4
+    Restock_Field: [0, 1, 1, 2, 0]

--- a/database/shops/general_store.yaml
+++ b/database/shops/general_store.yaml
@@ -9,8 +9,8 @@ Items:
     Base_Sell: null
     Infinite: true
     R: 1.0
-    R_Max: 1.0
-    Volume_Sensitivity: 0
+    R_Max: 2.5
+    Volume_Sensitivity: 30
     Transaction_Threshold: 999
     Stock_Max: 9999
     Stock_Influence: 0
@@ -20,8 +20,8 @@ Items:
     Base_Buy: 5
     Base_Sell: null
     R: 1.0
-    R_Max: 1.0
-    Volume_Sensitivity: 0
+    R_Max: 2.5
+    Volume_Sensitivity: 30
     Transaction_Threshold: 999
     Stock_Max: 9999
     Stock_Influence: 0
@@ -31,8 +31,8 @@ Items:
     Base_Buy: 8
     Base_Sell: 2
     R: 1.0
-    R_Max: 1.0
-    Volume_Sensitivity: 0
+    R_Max: 2.5
+    Volume_Sensitivity: 30
     Transaction_Threshold: 999
     Stock_Max: 9999
     Stock_Influence: 0
@@ -42,8 +42,8 @@ Items:
     Base_Buy: 30
     Base_Sell: 10
     R: 1.0
-    R_Max: 1.0
-    Volume_Sensitivity: 0
+    R_Max: 2.5
+    Volume_Sensitivity: 30
     Transaction_Threshold: 999
     Stock_Max: 9999
     Stock_Influence: 0
@@ -53,8 +53,8 @@ Items:
     Base_Buy: 15
     Base_Sell: 5
     R: 1.0
-    R_Max: 1.0
-    Volume_Sensitivity: 0
+    R_Max: 2.5
+    Volume_Sensitivity: 30
     Transaction_Threshold: 999
     Stock_Max: 9999
     Stock_Influence: 0
@@ -64,8 +64,8 @@ Items:
     Base_Buy: 100
     Base_Sell: 30
     R: 1.0
-    R_Max: 1.0
-    Volume_Sensitivity: 0
+    R_Max: 2.5
+    Volume_Sensitivity: 30
     Transaction_Threshold: 999
     Stock_Max: 9999
     Stock_Influence: 0
@@ -76,7 +76,7 @@ Items:
     Base_Sell: 6
     R: 3.0
     R_Max: 3.99
-    Volume_Sensitivity: 750
+    Volume_Sensitivity: 100
     Transaction_Threshold: 20
     Stock_Max: 1000
     Stock_Influence: 0.1
@@ -87,7 +87,7 @@ Items:
     Base_Sell: 30
     R: 3.0
     R_Max: 3.99
-    Volume_Sensitivity: 150
+    Volume_Sensitivity: 30
     Transaction_Threshold: 10
     Stock_Max: 200
     Stock_Influence: 0.2
@@ -98,7 +98,7 @@ Items:
     Base_Sell: 50
     R: 3.0
     R_Max: 3.99
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 10
     Transaction_Threshold: 5
     Stock_Max: 50
     Stock_Influence: 0.35

--- a/database/shops/general_store.yaml
+++ b/database/shops/general_store.yaml
@@ -60,6 +60,17 @@ Items:
     Stock_Influence: 0
     Restock_Field: [10]
 
+  - id: tar_bait
+    Base_Buy: 60
+    Base_Sell: 18
+    R: 1.0
+    R_Max: 2.5
+    Volume_Sensitivity: 30
+    Transaction_Threshold: 999
+    Stock_Max: 9999
+    Stock_Influence: 0
+    Restock_Field: [10]
+
   - id: bear_bait
     Base_Buy: 100
     Base_Sell: 30

--- a/database/shops/general_store.yaml
+++ b/database/shops/general_store.yaml
@@ -71,6 +71,18 @@ Items:
     Stock_Influence: 0
     Restock_Field: [10]
 
+  # Misc crafting material — buy-only, demand-responsive within a tight band
+  - id: card_deck
+    Base_Buy: 10
+    Base_Sell: null
+    R: 2.0
+    R_Max: 2.5
+    Volume_Sensitivity: 100
+    Transaction_Threshold: 15
+    Stock_Max: 500
+    Stock_Influence: 0.2
+    Restock_Field: [15, 25, 30, 40, 0]
+
   - id: swallow_feather
     Base_Buy: 10
     Base_Sell: 6

--- a/database/shops/general_store.yaml
+++ b/database/shops/general_store.yaml
@@ -71,10 +71,10 @@ Items:
     Stock_Influence: 0
     Restock_Field: [10]
 
-  # Misc crafting material — buy-only, demand-responsive within a tight band
+  # Misc crafting material — demand-responsive within a tight band
   - id: card_deck
     Base_Buy: 10
-    Base_Sell: null
+    Base_Sell: 3
     R: 2.0
     R_Max: 2.5
     Volume_Sensitivity: 100

--- a/database/shops/general_store.yaml
+++ b/database/shops/general_store.yaml
@@ -74,8 +74,8 @@ Items:
   - id: swallow_feather
     Base_Buy: 10
     Base_Sell: 6
-    R: 1.5
-    R_Max: 2.5
+    R: 3.0
+    R_Max: 3.99
     Volume_Sensitivity: 750
     Transaction_Threshold: 20
     Stock_Max: 1000
@@ -85,8 +85,8 @@ Items:
   - id: venison
     Base_Buy: 50
     Base_Sell: 30
-    R: 2.2
-    R_Max: 3.2
+    R: 3.0
+    R_Max: 3.99
     Volume_Sensitivity: 150
     Transaction_Threshold: 10
     Stock_Max: 200
@@ -96,8 +96,8 @@ Items:
   - id: maek_egg
     Base_Buy: 70
     Base_Sell: 50
-    R: 2.8
-    R_Max: 3.7
+    R: 3.0
+    R_Max: 3.99
     Volume_Sensitivity: 40
     Transaction_Threshold: 5
     Stock_Max: 50

--- a/database/shops/lumberjack.yaml
+++ b/database/shops/lumberjack.yaml
@@ -8,8 +8,8 @@ Items:
   - id: sulwood
     Base_Buy: 100
     Base_Sell: 20
-    R: 1.8
-    R_Max: 3.0
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 400
     Transaction_Threshold: 15
     Stock_Max: 500
@@ -21,7 +21,7 @@ Items:
     Base_Buy: 200
     Base_Sell: 40
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 100
     Transaction_Threshold: 10
     Stock_Max: 200
@@ -31,8 +31,8 @@ Items:
   - id: hardwood
     Base_Buy: 400
     Base_Sell: 80
-    R: 2.2
-    R_Max: 3.2
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 50
     Transaction_Threshold: 6
     Stock_Max: 80
@@ -44,7 +44,7 @@ Items:
     Base_Buy: 500
     Base_Sell: 100
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -55,7 +55,7 @@ Items:
     Base_Buy: 700
     Base_Sell: 140
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -66,7 +66,7 @@ Items:
     Base_Buy: 800
     Base_Sell: 160
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -77,7 +77,7 @@ Items:
     Base_Buy: 800
     Base_Sell: 160
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -88,7 +88,7 @@ Items:
     Base_Buy: 800
     Base_Sell: 160
     R: 2.0
-    R_Max: 3.2
+    R_Max: 3.4
     Volume_Sensitivity: 15
     Transaction_Threshold: 5
     Stock_Max: 20
@@ -100,7 +100,7 @@ Items:
     Base_Buy: 300
     Base_Sell: 60
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 40
     Transaction_Threshold: 8
     Stock_Max: 50
@@ -111,7 +111,7 @@ Items:
     Base_Buy: 300
     Base_Sell: 60
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 40
     Transaction_Threshold: 8
     Stock_Max: 50
@@ -122,7 +122,7 @@ Items:
     Base_Buy: 300
     Base_Sell: 60
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 40
     Transaction_Threshold: 8
     Stock_Max: 50
@@ -133,7 +133,7 @@ Items:
     Base_Buy: 300
     Base_Sell: 60
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 40
     Transaction_Threshold: 8
     Stock_Max: 50
@@ -145,7 +145,7 @@ Items:
     Base_Buy: 400
     Base_Sell: 80
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 40
     Transaction_Threshold: 8
     Stock_Max: 50
@@ -156,7 +156,7 @@ Items:
     Base_Buy: 400
     Base_Sell: 80
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 40
     Transaction_Threshold: 8
     Stock_Max: 50
@@ -167,7 +167,7 @@ Items:
     Base_Buy: 400
     Base_Sell: 80
     R: 2.0
-    R_Max: 3.0
+    R_Max: 3.4
     Volume_Sensitivity: 40
     Transaction_Threshold: 8
     Stock_Max: 50
@@ -178,8 +178,8 @@ Items:
   - id: sword_blade_hardwood
     Base_Buy: 800
     Base_Sell: 160
-    R: 2.2
-    R_Max: 3.3
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 20
     Transaction_Threshold: 5
     Stock_Max: 25
@@ -189,8 +189,8 @@ Items:
   - id: axe_head_hardwood
     Base_Buy: 800
     Base_Sell: 160
-    R: 2.2
-    R_Max: 3.3
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 20
     Transaction_Threshold: 5
     Stock_Max: 25
@@ -200,8 +200,8 @@ Items:
   - id: shovel_head_hardwood
     Base_Buy: 800
     Base_Sell: 160
-    R: 2.2
-    R_Max: 3.3
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 20
     Transaction_Threshold: 5
     Stock_Max: 25
@@ -211,8 +211,8 @@ Items:
   - id: wand_base_hardwood
     Base_Buy: 600
     Base_Sell: 120
-    R: 2.2
-    R_Max: 3.3
+    R: 2.0
+    R_Max: 3.4
     Volume_Sensitivity: 20
     Transaction_Threshold: 5
     Stock_Max: 25
@@ -223,8 +223,8 @@ Items:
   - id: felt_hat
     Base_Buy: 100
     Base_Sell: 25
-    R: 1.8
-    R_Max: 2.8
+    R: 3.0
+    R_Max: 3.99
     Volume_Sensitivity: 400
     Transaction_Threshold: 15
     Stock_Max: 500
@@ -235,7 +235,7 @@ Items:
     Base_Buy: 1000
     Base_Sell: 500
     R: 3.0
-    R_Max: 3.8
+    R_Max: 3.99
     Volume_Sensitivity: 8
     Transaction_Threshold: 3
     Stock_Max: 10
@@ -246,7 +246,7 @@ Items:
     Base_Buy: 1200
     Base_Sell: 600
     R: 3.0
-    R_Max: 3.8
+    R_Max: 3.99
     Volume_Sensitivity: 8
     Transaction_Threshold: 3
     Stock_Max: 12

--- a/database/shops/lumberjack.yaml
+++ b/database/shops/lumberjack.yaml
@@ -252,3 +252,14 @@ Items:
     Stock_Max: 12
     Stock_Influence: 0.4
     Restock_Field: [0, 1, 1, 2, 0]
+
+  - id: bottle_of_tar
+    Base_Buy: 90
+    Base_Sell: 30
+    R: 3.0
+    R_Max: 3.99
+    Volume_Sensitivity: 80
+    Transaction_Threshold: 12
+    Stock_Max: 300
+    Stock_Influence: 0.15
+    Restock_Field: [15, 25, 30, 40, 0]

--- a/database/shops/lumberjack.yaml
+++ b/database/shops/lumberjack.yaml
@@ -10,7 +10,7 @@ Items:
     Base_Sell: 20
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 400
+    Volume_Sensitivity: 50
     Transaction_Threshold: 15
     Stock_Max: 500
     Stock_Influence: 0.2
@@ -22,7 +22,7 @@ Items:
     Base_Sell: 40
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 100
+    Volume_Sensitivity: 20
     Transaction_Threshold: 10
     Stock_Max: 200
     Stock_Influence: 0.2
@@ -33,7 +33,7 @@ Items:
     Base_Sell: 80
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 50
+    Volume_Sensitivity: 10
     Transaction_Threshold: 6
     Stock_Max: 80
     Stock_Influence: 0.25
@@ -45,7 +45,7 @@ Items:
     Base_Sell: 100
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -56,7 +56,7 @@ Items:
     Base_Sell: 140
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -67,7 +67,7 @@ Items:
     Base_Sell: 160
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -78,7 +78,7 @@ Items:
     Base_Sell: 160
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -89,7 +89,7 @@ Items:
     Base_Sell: 160
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 15
+    Volume_Sensitivity: 4
     Transaction_Threshold: 5
     Stock_Max: 20
     Stock_Influence: 0.3
@@ -101,7 +101,7 @@ Items:
     Base_Sell: 60
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 8
     Transaction_Threshold: 8
     Stock_Max: 50
     Stock_Influence: 0.2
@@ -112,7 +112,7 @@ Items:
     Base_Sell: 60
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 8
     Transaction_Threshold: 8
     Stock_Max: 50
     Stock_Influence: 0.2
@@ -123,7 +123,7 @@ Items:
     Base_Sell: 60
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 8
     Transaction_Threshold: 8
     Stock_Max: 50
     Stock_Influence: 0.2
@@ -134,7 +134,7 @@ Items:
     Base_Sell: 60
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 8
     Transaction_Threshold: 8
     Stock_Max: 50
     Stock_Influence: 0.2
@@ -146,7 +146,7 @@ Items:
     Base_Sell: 80
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 8
     Transaction_Threshold: 8
     Stock_Max: 50
     Stock_Influence: 0.2
@@ -157,7 +157,7 @@ Items:
     Base_Sell: 80
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 8
     Transaction_Threshold: 8
     Stock_Max: 50
     Stock_Influence: 0.2
@@ -168,7 +168,7 @@ Items:
     Base_Sell: 80
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 40
+    Volume_Sensitivity: 8
     Transaction_Threshold: 8
     Stock_Max: 50
     Stock_Influence: 0.2
@@ -180,7 +180,7 @@ Items:
     Base_Sell: 160
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 20
+    Volume_Sensitivity: 5
     Transaction_Threshold: 5
     Stock_Max: 25
     Stock_Influence: 0.25
@@ -191,7 +191,7 @@ Items:
     Base_Sell: 160
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 20
+    Volume_Sensitivity: 5
     Transaction_Threshold: 5
     Stock_Max: 25
     Stock_Influence: 0.25
@@ -202,7 +202,7 @@ Items:
     Base_Sell: 160
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 20
+    Volume_Sensitivity: 5
     Transaction_Threshold: 5
     Stock_Max: 25
     Stock_Influence: 0.25
@@ -213,7 +213,7 @@ Items:
     Base_Sell: 120
     R: 2.0
     R_Max: 3.4
-    Volume_Sensitivity: 20
+    Volume_Sensitivity: 5
     Transaction_Threshold: 5
     Stock_Max: 25
     Stock_Influence: 0.25
@@ -225,7 +225,7 @@ Items:
     Base_Sell: 25
     R: 3.0
     R_Max: 3.99
-    Volume_Sensitivity: 400
+    Volume_Sensitivity: 80
     Transaction_Threshold: 15
     Stock_Max: 500
     Stock_Influence: 0.15
@@ -236,7 +236,7 @@ Items:
     Base_Sell: 500
     R: 3.0
     R_Max: 3.99
-    Volume_Sensitivity: 8
+    Volume_Sensitivity: 3
     Transaction_Threshold: 3
     Stock_Max: 10
     Stock_Influence: 0.4
@@ -247,7 +247,7 @@ Items:
     Base_Sell: 600
     R: 3.0
     R_Max: 3.99
-    Volume_Sensitivity: 8
+    Volume_Sensitivity: 3
     Transaction_Threshold: 3
     Stock_Max: 12
     Stock_Influence: 0.4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,20 +5,53 @@ to the Discord #updates channel lives at `docs/CHANGELOG_DISCORD.md`.
 
 ## 0.1.4 — 2026-06-03
 
-Economy tuning so prices actually react to player trading, plus changelog
-infrastructure (Discord vs detailed split).
+Mobile-friendly UI, keyboard combat controls, the Golnosar joins the
+roster, a few item renames, and economy tuning so prices actually
+react to player trading.
+
+### Mobile
+- **Responsive top-level layout** — collapsing sidebar becomes a hamburger drawer below 720px, header reflows, content columns stack vertically. Tested down to a 390px viewport.
+- **Battle board scales** — cell size now drives off a `--cell-size` CSS variable. On mobile, layout stacks vertically (board above controls) and cells shrink to 44px so a 7-wide board fits in 308px instead of overflowing 504px. Touch-friendly action buttons sized at 44px+ minimum.
+
+### UI Polish
+- **ALL buttons restored** — sell-stack and craft-max buttons in the shop and crafting panels. One click to dump the full stack or craft the most a budget allows.
+- **Battle keyboard input** — arrow keys move (or click-target), `1`–`9` selects action by index, `Enter` confirms / skips / returns to town. Hunt page also accepts `Enter` to confirm bait selection.
+
+### New Content
+- **New enemy: Golnosar** (Level 4, 110 HP). Pool-dwelling living-tar creature. Resource: Tar (max 10). Tar Drink (defend, blocks 10 + restores 10 Tar), Tar Shot (attack, reactive, range 3, swingy 0–8 blunt), Blind crit (DOT, 10 per round for 3 rounds), Fistar (special, aimed, range 4, arcane fire DOT 5–14 for 5 rounds). 8-step pattern (drink → 4× shot → fistar → 2× shot). Sim shows ~40% win rate on Talamite Axe/Shovel with 50% aim-miss assumption.
+- **Tar Bait** at the general store (60 buy / 18 sell). Summons Golnosar.
+- **Bottle of Tar** drops to the lumberjack (90/30, used for waterproofing).
+- **Lifgem** drops as a rare valuable (1-in-20 from Golnosar). Goes to the enchanter (800/400). Priced for "will become more common when other enemies drop it" — moderate stock cap, modest unit value.
+- **Card Deck** new general-store material (10/3). Recipe ingredient for both Deck of Cards weapon and its Nodol upgrade. Flavor: "A simple deck of cards with the Chae emperor, Gustavus, as the king."
+- **Lore: Emperor Gustavus** — the previously unnamed Chae emperor now has a name. His face is stamped on every korel coin (the most common way subjects see him), and on the king card in standard playing decks. Added to `database/lore/world.md`.
+
+### Renames
+- **`bear_teeth` → `melstone`** — flavor reframe ("a dense stone passed through a melbear's gut, worn smooth — used as a heat-resistant core"). Updated in items.ts, melbear.yaml drop, blacksmith.yaml shop listing.
+- **`diamond` → `lifgem`** — diamond was placeholder; lifgem fits the world (faintly pulsing gemstone the enchanter pays for). Repriced for projected future drops from other enemies.
+- **Production migration required on release**:
+  ```sql
+  UPDATE "ShopItemState"   SET item_id='melstone' WHERE item_id='bear_teeth';
+  UPDATE "ShopTransaction" SET item_id='melstone' WHERE item_id='bear_teeth';
+  UPDATE "InventoryItem"   SET item_id='melstone' WHERE item_id='bear_teeth';
+  UPDATE "ShopItemState"   SET item_id='lifgem'   WHERE item_id='diamond';
+  UPDATE "ShopTransaction" SET item_id='lifgem'   WHERE item_id='diamond';
+  UPDATE "InventoryItem"   SET item_id='lifgem'   WHERE item_id='diamond';
+  ```
 
 ### Economy
 - **R / R_Max tier split** — three pricing personalities now baked in:
   - **Bulk** (raw + intermediate + tier-3 materials, components, weapons): `R: 2.0`, `R_Max: 3.4`. Period-doubling band. Mostly predictable, mild oscillation under heavy trading. Grinder-friendly.
-  - **Valuables** (loot drops — swallow_feather, venison, maek_egg, crystal_tooth, felt_hat, antler_trophy, bear_teeth, bear_paw): `R: 3.0`, `R_Max: 3.99`. Full chaos band. Prices swing tick-to-tick under any sustained traffic. Sellers should time the market.
+  - **Valuables** (loot drops — swallow_feather, venison, maek_egg, crystal_tooth, felt_hat, antler_trophy, melstone, bear_paw, bottle_of_tar, lifgem): `R: 3.0`, `R_Max: 3.99`. Full chaos band. Prices swing tick-to-tick under any sustained traffic. Sellers should time the market.
   - **Baits**: `R: 1.0`, `R_Max: 2.5`. Idle decay toward floor, demand pushes back up to ~1.5× baseline. No chaos (stable convergence band).
 - **Volume_Sensitivity slashed** — old values needed unreachable volume (thuvel needed ~56,000 cumulative units to push r meaningfully). Cut roughly 5–8× across the board:
   - Bulk raw 400 → 50, intermediates 100 → 20, tier-3 mats 50 → 10
   - Components tier-2 40 → 8, tier-3 20 → 5, weapons 15 → 4
-  - Valuables: swallow_feather 750 → 100, crystal_tooth/felt_hat 400 → 80, bear_teeth 200 → 30, venison 150 → 30, maek_egg 40 → 10, antler_trophy/bear_paw 8 → 3
+  - Valuables: swallow_feather 750 → 100, crystal_tooth/felt_hat 400 → 80, melstone 200 → 30, venison 150 → 30, maek_egg 40 → 10, antler_trophy/bear_paw 8 → 3
   - Baits 0 → 30 (was special-cased to skip the formula entirely)
 - **Bait demand is responsive** — `Volume_Sensitivity` was 0 (locked at R=1.0 regardless of volume), now 30. Combined with R_Max 2.5, hammered baits walk price up to ~1.5× baseline; idle baits decay back toward the floor.
+
+### Tooling
+- **Simulator: aimed-attack hit roll** — `src/tools/simulate.ts` now rolls 50% hit/miss on any `aimed: true` action (both sides). Without this, sim treated every aimed shot as a hit, which inflated DOT-heavy specials like Fistar and Ursa Major. Real combat is spatial and targets can dodge by moving off the tile. Sim-only; combat engine unchanged.
 
 ### Infrastructure
 - **Discord changelog split** — `docs/CHANGELOG.md` stays detailed for dev/devops; new `docs/CHANGELOG_DISCORD.md` is condensed and player-safe. The version auto-announcer (`extractChangelogSection`) now reads from the Discord file so spoiler-heavy enemy specs and code-level detail don't leak into the public channel.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+The detailed, dev-side log. The condensed, player-facing version that goes
+to the Discord #updates channel lives at `docs/CHANGELOG_DISCORD.md`.
+
+## 0.1.4 — 2026-06-03
+
+Economy tuning so prices actually react to player trading, plus changelog
+infrastructure (Discord vs detailed split).
+
+### Economy
+- **R / R_Max tier split** — three pricing personalities now baked in:
+  - **Bulk** (raw + intermediate + tier-3 materials, components, weapons): `R: 2.0`, `R_Max: 3.4`. Period-doubling band. Mostly predictable, mild oscillation under heavy trading. Grinder-friendly.
+  - **Valuables** (loot drops — swallow_feather, venison, maek_egg, crystal_tooth, felt_hat, antler_trophy, bear_teeth, bear_paw): `R: 3.0`, `R_Max: 3.99`. Full chaos band. Prices swing tick-to-tick under any sustained traffic. Sellers should time the market.
+  - **Baits**: `R: 1.0`, `R_Max: 2.5`. Idle decay toward floor, demand pushes back up to ~1.5× baseline. No chaos (stable convergence band).
+- **Volume_Sensitivity slashed** — old values needed unreachable volume (thuvel needed ~56,000 cumulative units to push r meaningfully). Cut roughly 5–8× across the board:
+  - Bulk raw 400 → 50, intermediates 100 → 20, tier-3 mats 50 → 10
+  - Components tier-2 40 → 8, tier-3 20 → 5, weapons 15 → 4
+  - Valuables: swallow_feather 750 → 100, crystal_tooth/felt_hat 400 → 80, bear_teeth 200 → 30, venison 150 → 30, maek_egg 40 → 10, antler_trophy/bear_paw 8 → 3
+  - Baits 0 → 30 (was special-cased to skip the formula entirely)
+- **Bait demand is responsive** — `Volume_Sensitivity` was 0 (locked at R=1.0 regardless of volume), now 30. Combined with R_Max 2.5, hammered baits walk price up to ~1.5× baseline; idle baits decay back toward the floor.
+
+### Infrastructure
+- **Discord changelog split** — `docs/CHANGELOG.md` stays detailed for dev/devops; new `docs/CHANGELOG_DISCORD.md` is condensed and player-safe. The version auto-announcer (`extractChangelogSection`) now reads from the Discord file so spoiler-heavy enemy specs and code-level detail don't leak into the public channel.
+
+---
+
 ## 0.1.3 — 2026-06-02
 
 Character creation and the tutorial-day hand-off move into the web app,

--- a/docs/CHANGELOG_DISCORD.md
+++ b/docs/CHANGELOG_DISCORD.md
@@ -1,0 +1,19 @@
+# Changelog (Discord)
+
+Condensed, player-facing changelog posted to the #updates channel on each new release. For full detail see `docs/CHANGELOG.md`.
+
+## 0.1.4 — 2026-06-03
+
+- Shop prices now respond to player trading — busy markets get volatile, quiet markets stay predictable.
+- Loot drop prices are in full chaos mode. Check the market before selling rare items.
+- Bait prices respond to demand too, so popular hunts get pricier over time.
+
+---
+
+## 0.1.3 — 2026-06-02
+
+- A new beast stalks the forest. Bring something heavy.
+- Each hunt's terrain rearranges itself between sessions.
+- Character creation has moved into the web app, with a guided tour for new arrivals.
+- Weapons and korel can now ride along in trades.
+- A handful of shop and combat fixes.

--- a/docs/CHANGELOG_DISCORD.md
+++ b/docs/CHANGELOG_DISCORD.md
@@ -4,6 +4,13 @@ Condensed, player-facing changelog posted to the #updates channel on each new re
 
 ## 0.1.4 — 2026-06-03
 
+- Something new is stirring in the tar pools. Bring a bait that matches.
+- A new oddity at the general store — and the enchanter knows what to do with it.
+- The emperor finally has a name. Check the lore page.
+- Idya plays on your phone now. Sidebar tucks into a menu, battle board fits the screen.
+- Combat keyboard controls: arrow keys to move, number keys to pick actions, Enter to confirm.
+- "ALL" buttons in the shop and crafting panels — one click to dump a stack or craft the max you can afford.
+- Renames: Bear Teeth → Melstone, Diamond → Lifgem (your stacks will carry over).
 - Shop prices now respond to player trading — busy markets get volatile, quiet markets stay predictable.
 - Loot drop prices are in full chaos mode. Check the market before selling rare items.
 - Bait prices respond to demand too, so popular hunts get pricier over time.

--- a/docs/CHANGELOG_DISCORD.md
+++ b/docs/CHANGELOG_DISCORD.md
@@ -5,12 +5,11 @@ Condensed, player-facing changelog posted to the #updates channel on each new re
 ## 0.1.4 — 2026-06-03
 
 - Something new is stirring in the tar pools. Bring a bait that matches.
-- A new oddity at the general store — and the enchanter knows what to do with it.
-- The emperor finally has a name. Check the lore page.
+- New item: Card Deck (general store), used to craft the Deck of Cards weapon.
 - Idya plays on your phone now. Sidebar tucks into a menu, battle board fits the screen.
 - Combat keyboard controls: arrow keys to move, number keys to pick actions, Enter to confirm.
 - "ALL" buttons in the shop and crafting panels — one click to dump a stack or craft the max you can afford.
-- Renames: Bear Teeth → Melstone, Diamond → Lifgem (your stacks will carry over).
+- Rename: Bear Teeth → Melstone (your stacks will carry over).
 - Shop prices now respond to player trading — busy markets get volatile, quiet markets stay predictable.
 - Loot drop prices are in full chaos mode. Check the market before selling rare items.
 - Bait prices respond to demand too, so popular hunts get pricier over time.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "//3": "updating this file will download and update your packages",
   "name": "idya",
   "type": "module",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "RPG Bot",
   "author": "pg805",
   "main": "./src/discord/init.ts",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "//3": "updating this file will download and update your packages",
   "name": "idya",
   "type": "module",
-  "version": "0.1.4",
+  "version": "0.1.3",
   "description": "RPG Bot",
   "author": "pg805",
   "main": "./src/discord/init.ts",

--- a/public/app.css
+++ b/public/app.css
@@ -81,8 +81,65 @@ body {
   text-align: center;
 }
 
+/* Hamburger / drawer — hidden on desktop, takes over on narrow viewports */
+#mobile-menu-toggle {
+  display: none;
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  width: 40px;
+  height: 40px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  z-index: 200;
+  cursor: pointer;
+  padding: 8px;
+  flex-direction: column;
+  justify-content: space-between;
+}
+#mobile-menu-toggle span {
+  display: block;
+  height: 2px;
+  background: var(--gold);
+  border-radius: 1px;
+  transition: transform 0.2s, opacity 0.2s;
+}
+body.menu-open #mobile-menu-toggle span:nth-child(1) { transform: translateY(9px) rotate(45deg); }
+body.menu-open #mobile-menu-toggle span:nth-child(2) { opacity: 0; }
+body.menu-open #mobile-menu-toggle span:nth-child(3) { transform: translateY(-9px) rotate(-45deg); }
+
+#mobile-menu-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 18, 27, 0.6);
+  z-index: 90;
+}
+body.menu-open #mobile-menu-backdrop { display: block; }
+
 @media (max-width: 640px) {
-  #app-sidebar { width: 140px; min-width: 140px; }
-  .nav-link { font-size: 0.75rem; padding: 7px 12px; }
-  .nav-label { padding-left: 12px; }
+  body { height: auto; min-height: 100vh; overflow: visible; }
+  #app-shell { flex-direction: column; }
+  #mobile-menu-toggle { display: flex; }
+
+  #app-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 240px;
+    min-width: 240px;
+    padding-top: 60px;
+    transform: translateX(-100%);
+    transition: transform 0.22s ease;
+    z-index: 100;
+    box-shadow: 2px 0 12px rgba(0, 0, 0, 0.4);
+  }
+  body.menu-open #app-sidebar { transform: translateX(0); }
+
+  #app-content {
+    width: 100%;
+    overflow-y: visible;
+  }
 }

--- a/public/app.html
+++ b/public/app.html
@@ -21,6 +21,11 @@
   <script>if (location.port === '3000') document.title += ' — Dev';</script>
 </head>
 <body>
+  <button id="mobile-menu-toggle" type="button" aria-label="Menu">
+    <span></span><span></span><span></span>
+  </button>
+  <div id="mobile-menu-backdrop"></div>
+
   <div id="layout-root"></div>
   <div id="app-shell">
     <nav id="app-sidebar">

--- a/public/app.js
+++ b/public/app.js
@@ -56,9 +56,20 @@ async function navigate(viewPath, { push = true } = {}) {
 for (const link of navLinks) {
   link.addEventListener('click', (e) => {
     e.preventDefault();
+    document.body.classList.remove('menu-open');
     navigate(link.dataset.path);
   });
 }
+
+// Mobile drawer toggle. The hamburger button and backdrop are sibling
+// elements at the top of <body>; tapping either toggles or closes the
+// drawer, and any nav-link click also closes (handled above).
+document.getElementById('mobile-menu-toggle')?.addEventListener('click', () => {
+  document.body.classList.toggle('menu-open');
+});
+document.getElementById('mobile-menu-backdrop')?.addEventListener('click', () => {
+  document.body.classList.remove('menu-open');
+});
 
 window.addEventListener('popstate', () => {
   navigate(viewPathFromUrl(), { push: false });

--- a/public/game.css
+++ b/public/game.css
@@ -202,6 +202,23 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
   vertical-align: middle;
 }
 .action-btn.selected .action-tag { background: var(--teal-dim); color: var(--text); }
+.action-key {
+  display: inline-block;
+  width: 16px;
+  text-align: center;
+  font-size: 0.65rem;
+  font-family: monospace;
+  color: var(--text-faint);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  margin-right: 6px;
+  padding: 0 2px;
+  vertical-align: middle;
+  line-height: 1.3;
+}
+.action-btn.selected .action-key { color: var(--teal-bright); border-color: var(--teal-dim); }
+.action-btn.unaffordable .action-key { opacity: 0.5; }
+@media (max-width: 640px) { .action-key { display: none; } }
 .submit-btn {
   background: var(--gold-bg);
   border: 1px solid var(--gold-dim);

--- a/public/game.css
+++ b/public/game.css
@@ -1,5 +1,7 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
+:root { --cell-size: 72px; }
+
 body {
   background: var(--bg);
   color: var(--text);
@@ -50,8 +52,8 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
 }
 
 .cell {
-  width: 72px;
-  height: 72px;
+  width: var(--cell-size);
+  height: var(--cell-size);
   background: var(--bg-surface);
   border-radius: 4px;
   display: flex;
@@ -334,3 +336,30 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
 #connection-status { font-size: 0.75rem; }
 #connection-status.connected { color: #4caf50; }
 #connection-status.disconnected { color: #d94a4a; }
+
+/* ---- Mobile (portrait phones) ----
+   Stack main-layout vertically and shrink board cells so a 7-wide board
+   fits inside a ~390px viewport without overflow. The js-driven width on
+   #left-col is overridden with !important since it's set inline. */
+@media (max-width: 640px) {
+  :root { --cell-size: 44px; }
+  #battle-shell { padding: 8px; gap: 8px; }
+  #main-layout {
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+    align-items: stretch;
+  }
+  #left-col { width: 100% !important; }
+  #right-col { width: 100%; }
+  #combat-log { height: 240px; }
+  .combatant { width: 32px; height: 32px; font-size: 0.7rem; border-width: 1px; }
+  .combatant-name { display: none; }
+  .cell[data-coord]::after { display: none; }
+  #combatant-list { flex-wrap: wrap; }
+  .combatant-card { min-width: 0; flex: 1 1 48%; padding: 8px 10px; }
+  h1 { font-size: 1rem; }
+  #log-header { padding: 6px 10px; }
+  #log-filters { font-size: 0.65rem; gap: 3px 8px; }
+  .action-btn { font-size: 0.8rem; padding: 5px 10px; }
+}

--- a/public/game.js
+++ b/public/game.js
@@ -257,14 +257,17 @@ function render() {
 
 function renderBoard() {
   const { width, height, obstacles } = state.board;
-  boardEl.style.gridTemplateColumns = `repeat(${width}, 72px)`;
-  // Lock #left-col to the board's pixel width. Otherwise the action panel's
-  // flex-wrap button row can be intrinsically wider than the board, which
-  // stretches the column on action-pick frames and snaps it back on
-  // waiting/idle frames — visible as the grid "jumping" and a blank gap
-  // appearing between the board and the combat log.
-  const boardPxWidth = width * 72 + (width - 1) * 3 + 18; // cells + gaps + padding(16) + border(2)
-  document.getElementById('left-col').style.width = `${boardPxWidth}px`;
+  // Cell size comes from the --cell-size CSS variable so the mobile media
+  // query can shrink the board (72px desktop, 44px phone) without JS knowing
+  // about breakpoints. Re-read each render so a viewport resize takes effect.
+  const cellSize = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--cell-size'), 10) || 72;
+  boardEl.style.gridTemplateColumns = `repeat(${width}, ${cellSize}px)`;
+  // Lock #left-col to the board's pixel width on wide viewports so the action
+  // panel's flex-wrap row doesn't stretch the column and snap it back between
+  // phases. On phones (<= 640px) the CSS overrides to width:100% — keep this
+  // pixel value off the inline style there so the override actually wins.
+  const boardPxWidth = width * cellSize + (width - 1) * 3 + 18; // cells + gaps + padding(16) + border(2)
+  document.getElementById('left-col').style.width = window.innerWidth <= 640 ? '' : `${boardPxWidth}px`;
   boardEl.innerHTML = '';
 
   const obstacleMap = new Map(obstacles.map(o => [`${o.pos.x},${o.pos.y}`, o]));

--- a/public/game.js
+++ b/public/game.js
@@ -317,7 +317,10 @@ function renderBoard() {
         cell.classList.add('move-target');
       } else if (ui.pathTiles.has(k) && !obstacle && !combatant) {
         cell.classList.add('path-tile');
-      } else if (ui.reachable.has(k) && !ui.moveTo && !obstacle && !combatant) {
+      } else if (ui.reachable.has(k) && ui.phase === 'selecting_move' && !obstacle && !combatant) {
+        // Keep reachable highlights up through the whole selecting_move phase
+        // (used to clear once moveTo was set) so arrow-key users can see how
+        // far they can still go from the current target.
         cell.classList.add('reachable');
       }
 
@@ -381,6 +384,14 @@ function renderActionPanel() {
       submit.addEventListener('click', submitIntent);
       actionPanelEl.appendChild(submit);
     }
+    return;
+  }
+
+  if (ui.phase === 'selecting_move') {
+    const hint = document.createElement('div');
+    hint.className = 'action-title';
+    hint.innerHTML = `Click or arrow keys to move · <span class="action-key">↵</span> to skip movement`;
+    actionPanelEl.appendChild(hint);
     return;
   }
 
@@ -537,6 +548,21 @@ function onKey(e) {
       return;
     }
     if (e.key === 'Enter' || e.key === ' ') {
+      // From idle -> select the player's combatant and skip straight to the
+      // action phase. Lets keyboard users hold position without arrowing back
+      // to the start tile.
+      if (ui.phase === 'idle') {
+        const player = myPlayerCombatant();
+        if (!player) return;
+        e.preventDefault();
+        ui.selected = player;
+        const { reachable, parents } = computeReachable(player);
+        ui.reachable = reachable;
+        ui.moveParents = parents;
+        ui.phase = 'selecting_action';
+        render();
+        return;
+      }
       // From selecting_move -> selecting_action (confirm move + start picking action)
       if (ui.phase === 'selecting_move') {
         e.preventDefault();

--- a/public/game.js
+++ b/public/game.js
@@ -404,13 +404,15 @@ function renderActionPanel() {
 
   const allActions = [...player.weaponInfo.actions, PASS_ACTION];
 
-  for (const action of allActions) {
+  for (let i = 0; i < allActions.length; i++) {
+    const action = allActions[i];
     const canAfford = action.cost <= 0 || action.cost <= player.resource;
     const btn = document.createElement('button');
     btn.className = `action-btn${actionIsSelected(action) ? ' selected' : ''}${canAfford ? '' : ' unaffordable'}`;
+    const keyHint = i < 9 ? `<span class="action-key">${i + 1}</span>` : '';
     btn.innerHTML = action.choice && action.choice !== 'pass'
-      ? `<span class="action-tag">${action.choice}</span> ${action.label}`
-      : action.label;
+      ? `${keyHint}<span class="action-tag">${action.choice}</span> ${action.label}`
+      : `${keyHint}${action.label}`;
     if (!canAfford) btn.disabled = true;
 
     const parts = [];
@@ -418,16 +420,7 @@ function renderActionPanel() {
     if (action.needsTarget) parts.push(`range ${action.range}`);
     if (parts.length) btn.title = parts.join(' · ');
 
-    btn.addEventListener('click', () => {
-      ui.action = action;
-      ui.targetTile = null;
-      if (action.needsTarget) {
-        ui.phase = 'selecting_target';
-        render();
-      } else {
-        renderActionPanel();
-      }
-    });
+    btn.addEventListener('click', () => pickAction(action));
     btns.appendChild(btn);
   }
   actionPanelEl.appendChild(btns);
@@ -479,6 +472,142 @@ function renderCombatantList() {
     combatantListEl.appendChild(card);
   }
 }
+
+// Shared action picker — used by both click handlers and keyboard shortcuts.
+function pickAction(action) {
+  if (!action) return;
+  const player = myPlayerCombatant();
+  if (!player) return;
+  const canAfford = action.cost <= 0 || action.cost <= player.resource;
+  if (!canAfford) return;
+  ui.action = action;
+  ui.targetTile = null;
+  if (action.needsTarget) {
+    ui.phase = 'selecting_target';
+    render();
+  } else {
+    renderActionPanel();
+  }
+}
+
+// ---- Keyboard ----
+// Arrow keys move the moveTo target (or the targetTile during aimed attacks).
+// Number keys 1-9 pick an action by visible order. Enter submits when the
+// intent is complete, Escape backs out one step.
+function onKey(e) {
+  if (!state || state.phase !== 'intent' || ui.phase === 'waiting' || ui.phase === 'ended') return;
+  // Don't intercept typing in inputs (currently none on the battle page, but defensive)
+  if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+
+  const dx = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0;
+  const dy = e.key === 'ArrowUp'   ? -1 : e.key === 'ArrowDown'  ? 1 : 0;
+
+  // --- Movement phases ---
+  if (ui.phase === 'idle' || ui.phase === 'selecting_move' || ui.phase === 'selecting_action') {
+    if (dx !== 0 || dy !== 0) {
+      e.preventDefault();
+      // Auto-select the player's combatant if nothing is selected yet
+      if (ui.phase === 'idle') {
+        const player = myPlayerCombatant();
+        if (!player) return;
+        ui.selected = player;
+        const { reachable, parents } = computeReachable(player);
+        ui.reachable = reachable;
+        ui.moveParents = parents;
+        ui.phase = 'selecting_move';
+      }
+      if (!ui.selected) return;
+      const from = ui.moveTo ?? ui.selected.pos;
+      const cand = { x: from.x + dx, y: from.y + dy };
+      const k = `${cand.x},${cand.y}`;
+      const origin = ui.selected.pos;
+      if (cand.x === origin.x && cand.y === origin.y) {
+        // Moving back to the starting tile = stay put
+        ui.moveTo = null;
+        ui.pathTiles = new Set();
+        if (ui.phase === 'selecting_action') ui.phase = 'selecting_move';
+      } else if (ui.reachable.has(k)) {
+        ui.moveTo = cand;
+        ui.pathTiles = getPathTiles(origin, cand, ui.moveParents);
+        if (ui.phase === 'selecting_action') ui.phase = 'selecting_move';
+      } else {
+        return;
+      }
+      render();
+      return;
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      // From selecting_move -> selecting_action (confirm move + start picking action)
+      if (ui.phase === 'selecting_move') {
+        e.preventDefault();
+        ui.phase = 'selecting_action';
+        render();
+        return;
+      }
+      // From selecting_action with an action set + no target needed -> submit
+      if (ui.phase === 'selecting_action' && ui.action && !ui.action.needsTarget) {
+        e.preventDefault();
+        submitIntent();
+        return;
+      }
+    }
+    // Numbers 1-9 pick an action while choosing one
+    if (ui.phase === 'selecting_action') {
+      const num = parseInt(e.key, 10);
+      if (num >= 1 && num <= 9) {
+        e.preventDefault();
+        const player = myPlayerCombatant();
+        if (!player?.weaponInfo) return;
+        const allActions = [...player.weaponInfo.actions, PASS_ACTION];
+        const action = allActions[num - 1];
+        if (action) pickAction(action);
+        return;
+      }
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      if (ui.phase === 'selecting_action') {
+        ui.phase = 'selecting_move';
+        ui.action = null;
+        render();
+      } else if (ui.phase === 'selecting_move') {
+        resetUI();
+        render();
+      }
+      return;
+    }
+  }
+
+  // --- Target-selection phase ---
+  if (ui.phase === 'selecting_target' && ui.action) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      if (ui.targetTile) { e.preventDefault(); submitIntent(); }
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      ui.phase = 'selecting_action';
+      ui.action = null;
+      ui.targetTile = null;
+      render();
+      return;
+    }
+    if (dx !== 0 || dy !== 0) {
+      e.preventDefault();
+      const fromPos = ui.moveTo ?? ui.selected?.pos;
+      if (!fromPos) return;
+      const targetable = computeTargetableTiles(ui.action, fromPos);
+      const seed = ui.targetTile ?? fromPos;
+      const cand = { x: seed.x + dx, y: seed.y + dy };
+      if (targetable.has(`${cand.x},${cand.y}`)) {
+        ui.targetTile = cand;
+        render();
+      }
+      return;
+    }
+  }
+}
+document.addEventListener('keydown', onKey);
 
 // ---- Interaction ----
 function onCellClick(x, y) {

--- a/public/game.js
+++ b/public/game.js
@@ -345,10 +345,10 @@ function renderActionPanel() {
       // Tutorial drops you on the character page with the town-tour flag so
       // app.js fires the sidebar walkthrough on first arrival.
       again.href = '/app/character?tour=1';
-      again.textContent = 'Go to Town';
+      again.innerHTML = 'Go to Town <span class="action-key">↵</span>';
     } else {
       again.href = '/app/hunt';
-      again.textContent = 'Return to Town';
+      again.innerHTML = 'Return to Town <span class="action-key">↵</span>';
     }
     actionPanelEl.appendChild(again);
     return;
@@ -506,9 +506,23 @@ function pickAction(action) {
 // Number keys 1-9 pick an action by visible order. Enter submits when the
 // intent is complete, Escape backs out one step.
 function onKey(e) {
-  if (!state || state.phase !== 'intent' || ui.phase === 'waiting' || ui.phase === 'ended') return;
+  if (!state) return;
   // Don't intercept typing in inputs (currently none on the battle page, but defensive)
   if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+
+  // Post-battle: Enter follows the Return/Go to Town link
+  if (ui.phase === 'ended') {
+    if (e.key === 'Enter' || e.key === ' ') {
+      const link = actionPanelEl.querySelector('a.battle-again-btn');
+      if (link?.href) {
+        e.preventDefault();
+        location.href = link.href;
+      }
+    }
+    return;
+  }
+
+  if (state.phase !== 'intent' || ui.phase === 'waiting') return;
 
   const dx = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0;
   const dy = e.key === 'ArrowUp'   ? -1 : e.key === 'ArrowDown'  ? 1 : 0;

--- a/public/layout.css
+++ b/public/layout.css
@@ -182,7 +182,20 @@
 .layout-train-btn:disabled { opacity: 0.35; cursor: default; }
 
 @media (max-width: 640px) {
+  /* Pad the title bar enough on the left for the hamburger button without
+     overlapping. Shrink title/korel text so the three-column header fits. */
+  .layout-title-bar {
+    padding: 12px 12px 12px 60px;
+    gap: 8px;
+  }
+  .layout-title     { font-size: 0.95rem; letter-spacing: 0.04em; }
+  .layout-char-name { font-size: 0.7rem;  letter-spacing: 0.05em; }
+  .layout-korel     { font-size: 0.78rem; white-space: nowrap; }
+
   .layout-sprite { width: 64px; min-width: 64px; }
   .layout-sprite img { width: 48px; height: 48px; }
   .layout-prof-cards { grid-template-columns: 1fr; }
+  .layout-prof       { padding: 8px 12px; }
+  .layout-prof-name  { font-size: 0.62rem; }
+  .layout-prof-level { font-size: 0.95rem; }
 }

--- a/public/views/bench.css
+++ b/public/views/bench.css
@@ -116,19 +116,63 @@ code  { background: var(--bg-darkest); padding: 2px 7px; border-radius: 3px; col
 .ingredient .have     { color: var(--teal-bright); }
 .ingredient .missing  { color: var(--warn-bright); }
 
-.craft-row { display: flex; align-items: center; gap: 8px; margin-top: 10px; }
+.craft-row { display: flex; align-items: center; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
 
-.craft-qty {
-  width: 52px;
+.craft-qty-ctrl {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   background: var(--bg-darkest);
   border: 1px solid var(--border);
   border-radius: 4px;
-  color: var(--text);
-  font-size: 0.8rem;
-  padding: 5px 6px;
-  text-align: center;
+  padding: 2px 4px;
 }
+.craft-qty-ctrl.disabled { opacity: 0.4; }
+
+.craft-step {
+  width: 22px;
+  height: 22px;
+  background: none;
+  border: none;
+  color: var(--buy);
+  font-size: 0.9rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+}
+.craft-step:hover:not(:disabled) { color: var(--buy-bright); }
+.craft-step:disabled { opacity: 0.3; cursor: default; }
+
+.craft-qty {
+  width: 44px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text);
+  font-size: 0.82rem;
+  padding: 3px 4px;
+  text-align: center;
+  font-family: monospace;
+  outline: none;
+}
+.craft-qty:focus { border-color: var(--gold-dim); }
 .craft-qty:disabled { opacity: 0.35; }
+
+.craft-all {
+  background: var(--bg-surface);
+  border: 1px solid var(--buy-dim);
+  border-radius: 3px;
+  color: var(--buy);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  padding: 2px 7px;
+  margin-left: 2px;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1.5;
+}
+.craft-all:hover:not(:disabled) { background: var(--buy-bg); color: var(--buy-bright); border-color: var(--buy); }
+.craft-all:disabled { opacity: 0.3; cursor: default; }
 
 .craft-btn {
   align-self: flex-start;

--- a/public/views/crafting.js
+++ b/public/views/crafting.js
@@ -114,7 +114,16 @@
               </div>
             </div>
             <div class="craft-row">
-              <input class="craft-qty" id="qty-${r.id}" type="number" min="1" max="99" value="1" ${r.available ? '' : 'disabled'}>
+              <div class="craft-qty-ctrl${r.available ? '' : ' disabled'}">
+                <button class="craft-step" onclick="Views.crafting.adjCraftQty('${r.id}', -1)" ${r.available ? '' : 'disabled'}>−</button>
+                <input class="craft-qty" id="qty-${r.id}" type="text" inputmode="numeric" pattern="[0-9]*"
+                  autocomplete="off" maxlength="3"
+                  value="1" data-max="${maxCraftable(r)}"
+                  oninput="Views.crafting.onQtyInput('${r.id}')"
+                  ${r.available ? '' : 'disabled'}>
+                <button class="craft-step" onclick="Views.crafting.adjCraftQty('${r.id}', 1)" ${r.available ? '' : 'disabled'}>+</button>
+                <button class="craft-all" onclick="Views.crafting.setCraftQty('${r.id}', ${maxCraftable(r)})" ${r.available ? '' : 'disabled'}>ALL</button>
+              </div>
               <button class="craft-btn" onclick="Views.crafting.doCraft('${r.id}')" ${r.available ? '' : 'disabled'}>Craft</button>
             </div>
           </div>` : ''}
@@ -126,6 +135,43 @@
   function toggleRecipe(id) {
     openRecipe = openRecipe === id ? null : id;
     renderRecipes();
+  }
+
+  // Max craftable based on current inventory — limited by the scarcest
+  // ingredient. Capped at 99 to match the server-side batch cap.
+  function maxCraftable(recipe) {
+    if (!recipe.available) return 0;
+    if (!recipe.ingredients || recipe.ingredients.length === 0) return 99;
+    const maxByIng = recipe.ingredients.map(i => {
+      const have = data.inventory[i.item_id] ?? 0;
+      return Math.floor(have / i.quantity);
+    });
+    return Math.max(0, Math.min(99, ...maxByIng));
+  }
+
+  function setCraftQty(recipeId, qty) {
+    const input = document.getElementById(`qty-${recipeId}`);
+    if (!input) return;
+    const max = parseInt(input.dataset.max, 10) || 1;
+    const clamped = Math.max(1, Math.min(max, Math.floor(qty)));
+    input.value = String(clamped);
+  }
+
+  function adjCraftQty(recipeId, delta) {
+    const input = document.getElementById(`qty-${recipeId}`);
+    if (!input) return;
+    const cur = parseInt(input.value, 10) || 1;
+    setCraftQty(recipeId, cur + delta);
+  }
+
+  // Input handler: strip non-digits, clamp to max in-place (preserves cursor).
+  function onQtyInput(recipeId) {
+    const input = document.getElementById(`qty-${recipeId}`);
+    if (!input) return;
+    const cleaned = input.value.replace(/\D/g, '');
+    const max = parseInt(input.dataset.max, 10) || 1;
+    const clamped = Math.max(0, Math.min(max, parseInt(cleaned, 10) || 0));
+    if (String(clamped) !== input.value) input.value = String(clamped);
   }
 
   async function doCraft(recipeId) {
@@ -157,6 +203,6 @@
   }
 
   window.Views = window.Views ?? {};
-  window.Views.crafting = { mount, unmount, toggleProf, toggleRecipe, doCraft };
+  window.Views.crafting = { mount, unmount, toggleProf, toggleRecipe, doCraft, adjCraftQty, setCraftQty, onQtyInput };
   window.showToast = (msg) => toast(msg, true);
 })();

--- a/public/views/hunt.css
+++ b/public/views/hunt.css
@@ -166,3 +166,19 @@
   color: var(--warn-bright);
   font-size: 0.85rem;
 }
+
+.hunt-key {
+  display: inline-block;
+  width: 18px;
+  text-align: center;
+  font-size: 0.7rem;
+  font-family: monospace;
+  color: var(--text-faint);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  margin-right: 8px;
+  padding: 1px 0;
+  vertical-align: middle;
+  line-height: 1.2;
+}
+@media (max-width: 640px) { .hunt-key { display: none; } }

--- a/public/views/hunt.js
+++ b/public/views/hunt.js
@@ -20,10 +20,23 @@
     setLayoutTitle('Hunt');
     root.innerHTML = `<div id="hunt-body"><p class="hunt-empty">Loading…</p></div>`;
     window.addEventListener('layout-changed', layoutChangedHandler);
+    window.addEventListener('keydown', onKey);
     await loadData();
   }
 
   function layoutChangedHandler() { if (data) loadData(); }
+
+  function onKey(e) {
+    if (!data || data.baits.length === 0 || starting) return;
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+    const num = parseInt(e.key, 10);
+    if (!(num >= 1 && num <= 9)) return;
+    const b = data.baits[num - 1];
+    if (!b) return;
+    e.preventDefault();
+    const btn = document.querySelector(`.hunt-start[data-bait="${b.bait_id}"]`);
+    startHunt(b.bait_id, btn);
+  }
 
   async function loadData() {
     const res = await fetch('/api/hunt');
@@ -62,14 +75,16 @@
       return;
     }
 
-    const cardsHtml = data.baits.map(b => `
+    const cardsHtml = data.baits.map((b, i) => {
+      const keyHint = i < 9 ? `<span class="hunt-key">${i + 1}</span>` : '';
+      return `
       <article class="hunt-card" data-bait="${esc(b.bait_id)}">
         <div class="hunt-card-art">
           <img src="${esc(b.enemy_sprite)}" alt="${esc(b.enemy_name)}" onerror="this.style.visibility='hidden'">
         </div>
         <div class="hunt-card-body">
           <div class="hunt-card-headline">
-            <h2 class="hunt-enemy-name">${esc(b.enemy_name)}</h2>
+            <h2 class="hunt-enemy-name">${keyHint}${esc(b.enemy_name)}</h2>
             <span class="hunt-hp">${b.enemy_health} HP</span>
           </div>
           <div class="hunt-bait-line">
@@ -87,7 +102,7 @@
           <button class="hunt-start" data-bait="${esc(b.bait_id)}">Start Hunt</button>
         </div>
       </article>
-    `).join('');
+    `;}).join('');
 
     body.innerHTML = `
       <header class="hunt-head">
@@ -143,6 +158,7 @@
 
   function unmount() {
     window.removeEventListener('layout-changed', layoutChangedHandler);
+    window.removeEventListener('keydown', onKey);
     data = null;
     starting = false;
   }

--- a/public/views/shop.css
+++ b/public/views/shop.css
@@ -97,6 +97,21 @@
 }
 .shop-step:hover:not(:disabled) { color: var(--buy-bright); }
 .shop-step:disabled { opacity: 0.25; cursor: default; }
+.shop-all {
+  background: var(--bg-darkest);
+  border: 1px solid var(--buy-dim);
+  border-radius: 3px;
+  color: var(--buy);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  padding: 2px 7px;
+  margin-left: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1.5;
+}
+.shop-all:hover:not(:disabled) { background: var(--buy-bg); color: var(--buy-bright); border-color: var(--buy); }
+.shop-all:disabled { opacity: 0.25; cursor: default; }
 .shop-step-val {
   min-width: 24px;
   text-align: center;

--- a/public/views/shop.js
+++ b/public/views/shop.js
@@ -183,6 +183,7 @@
               <button class="shop-step" onclick="Views.shop.adjCart('sells', '${inv.item_id}', -1, ${maxQty})" ${qty <= 0 ? 'disabled' : ''}>−</button>
               <span class="shop-step-val">${qty}</span>
               <button class="shop-step" onclick="Views.shop.adjCart('sells', '${inv.item_id}', 1, ${maxQty})" ${qty >= maxQty ? 'disabled' : ''}>+</button>
+              <button class="shop-all" onclick="Views.shop.setCartQty('sells', '${inv.item_id}', ${maxQty})" ${qty >= maxQty ? 'disabled' : ''}>ALL</button>
             </div>`}
         </div>
       `;

--- a/src/economy/items.ts
+++ b/src/economy/items.ts
@@ -44,6 +44,7 @@ export const ITEMS: Record<string, ItemDef> = {
     deer_bait:    { name: 'Deer Bait',     description: 'A pouch of dried herbs from the forest floor. Daefen deer follow the smell for miles.', type: 'consumable' },
     toad_bait:    { name: 'Toad Bait',     description: 'A jar of murky pond water. Maetoads surface when they smell their own.',                type: 'consumable' },
     bear_bait:    { name: 'Bear Bait',     description: 'A bloody slab of game wrapped in waxed cloth. A melbear can smell it from a den away.', type: 'consumable' },
+    tar_bait:     { name: 'Tar Bait',      description: 'A pungent slick of black resin. Golnosar nest in tar pools and rise when they smell their own.', type: 'consumable' },
 
     // Misc materials sold at the general store
     card_deck:    { name: 'Card Deck',     description: 'A simple deck of cards with the Chae emperor, Gustavus, as the king. Common in town, occasionally enchanted by those who know how.', type: 'material'   },
@@ -57,4 +58,6 @@ export const ITEMS: Record<string, ItemDef> = {
     antler_trophy:   { name: 'Antler Trophy',   description: 'A full rack of burning antlers from a daefen deer. Impressive wall art.',         type: 'valuable'   },
     bear_teeth:      { name: 'Bear Teeth',      description: 'Thick canine teeth from a melbear. A blacksmith can mount them as edged tools.',  type: 'valuable'   },
     bear_paw:        { name: 'Bear Paw',        description: 'A massive melbear paw, fur and claws intact. The lumberjack pays well for one.',  type: 'valuable'   },
+    bottle_of_tar:   { name: 'Bottle of Tar',   description: 'A glass bottle of black, oily resin drained from a golnosar. The lumberjack uses it for waterproofing tools.', type: 'valuable'   },
+    diamond:         { name: 'Diamond',         description: 'A flawless gemstone, found lodged in a golnosar\'s hide. The enchanter pays a fortune for one.', type: 'valuable'   },
 };

--- a/src/economy/items.ts
+++ b/src/economy/items.ts
@@ -46,7 +46,7 @@ export const ITEMS: Record<string, ItemDef> = {
     bear_bait:    { name: 'Bear Bait',     description: 'A bloody slab of game wrapped in waxed cloth. A melbear can smell it from a den away.', type: 'consumable' },
 
     // Misc materials sold at the general store
-    card_deck:    { name: 'Card Deck',     description: 'A blank deck of paper cards. An enchanter can charge it into a Deck of Cards weapon.', type: 'material'   },
+    card_deck:    { name: 'Card Deck',     description: 'A simple deck of cards with the Chae emperor as the king. Common in town, occasionally enchanted by those who know how.', type: 'material'   },
 
     // Valuables — dropped by enemies, sold at shops
     swallow_feather: { name: 'Swallow Feather', description: 'A sleek feather from a lithkem swallow. Light and iridescent.',                   type: 'valuable'   },

--- a/src/economy/items.ts
+++ b/src/economy/items.ts
@@ -56,8 +56,8 @@ export const ITEMS: Record<string, ItemDef> = {
     crystal_tooth:   { name: 'Crystal Tooth',   description: 'A crystallized tooth shed by a talwyrm. Dense and faintly luminous.',             type: 'valuable'   },
     felt_hat:        { name: 'Felt Hat',        description: 'A wide-brimmed felt hat. Someone left it in the woods.',                         type: 'valuable'   },
     antler_trophy:   { name: 'Antler Trophy',   description: 'A full rack of burning antlers from a daefen deer. Impressive wall art.',         type: 'valuable'   },
-    bear_teeth:      { name: 'Bear Teeth',      description: 'Thick canine teeth from a melbear. A blacksmith can mount them as edged tools.',  type: 'valuable'   },
+    melstone:        { name: 'Melstone',        description: 'A dense, polished stone passed through a melbear\'s gut and worn smooth. The blacksmith uses them as heat-resistant cores.', type: 'valuable'   },
     bear_paw:        { name: 'Bear Paw',        description: 'A massive melbear paw, fur and claws intact. The lumberjack pays well for one.',  type: 'valuable'   },
     bottle_of_tar:   { name: 'Bottle of Tar',   description: 'A glass bottle of black, oily resin drained from a golnosar. The lumberjack uses it for waterproofing tools.', type: 'valuable'   },
-    diamond:         { name: 'Diamond',         description: 'A flawless gemstone, found lodged in a golnosar\'s hide. The enchanter pays a fortune for one.', type: 'valuable'   },
+    lifgem:          { name: 'Lifgem',          description: 'A faintly pulsing gemstone. The enchanter pays for any that come through the door.', type: 'valuable'   },
 };

--- a/src/economy/items.ts
+++ b/src/economy/items.ts
@@ -46,7 +46,7 @@ export const ITEMS: Record<string, ItemDef> = {
     bear_bait:    { name: 'Bear Bait',     description: 'A bloody slab of game wrapped in waxed cloth. A melbear can smell it from a den away.', type: 'consumable' },
 
     // Misc materials sold at the general store
-    card_deck:    { name: 'Card Deck',     description: 'A simple deck of cards with the Chae emperor as the king. Common in town, occasionally enchanted by those who know how.', type: 'material'   },
+    card_deck:    { name: 'Card Deck',     description: 'A simple deck of cards with the Chae emperor, Gustavus, as the king. Common in town, occasionally enchanted by those who know how.', type: 'material'   },
 
     // Valuables — dropped by enemies, sold at shops
     swallow_feather: { name: 'Swallow Feather', description: 'A sleek feather from a lithkem swallow. Light and iridescent.',                   type: 'valuable'   },

--- a/src/economy/items.ts
+++ b/src/economy/items.ts
@@ -45,6 +45,9 @@ export const ITEMS: Record<string, ItemDef> = {
     toad_bait:    { name: 'Toad Bait',     description: 'A jar of murky pond water. Maetoads surface when they smell their own.',                type: 'consumable' },
     bear_bait:    { name: 'Bear Bait',     description: 'A bloody slab of game wrapped in waxed cloth. A melbear can smell it from a den away.', type: 'consumable' },
 
+    // Misc materials sold at the general store
+    card_deck:    { name: 'Card Deck',     description: 'A blank deck of paper cards. An enchanter can charge it into a Deck of Cards weapon.', type: 'material'   },
+
     // Valuables — dropped by enemies, sold at shops
     swallow_feather: { name: 'Swallow Feather', description: 'A sleek feather from a lithkem swallow. Light and iridescent.',                   type: 'valuable'   },
     venison:         { name: 'Venison',         description: 'Fresh meat from a daefen deer. Worth good korel at the general store.',           type: 'valuable'   },

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2666,9 +2666,11 @@ async function notifyBotLog(title: string, color: number, fields: { name: string
   } catch (_) {}
 }
 
-// Extract a single version's section from CHANGELOG.md. Returns null if not found.
+// Extract a single version's section from the Discord-facing changelog.
+// CHANGELOG.md is the detailed dev-side log; CHANGELOG_DISCORD.md is the
+// condensed, player-safe version posted to #updates.
 function extractChangelogSection(version: string): string | null {
-  const path = join(__dirname, '../../docs/CHANGELOG.md');
+  const path = join(__dirname, '../../docs/CHANGELOG_DISCORD.md');
   if (!fs.existsSync(path)) return null;
   const md = fs.readFileSync(path, 'utf-8');
   // Split on '## ' h2 headings so each section starts with "VERSION ..." then body.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -184,7 +184,7 @@ function refreshTelegraphs(session: CombatSession): void {
 
 // ---- Session creation ----
 
-const VALID_ENEMIES = ['lithkem_swallow', 'sulfolk', 'talwyrm', 'daefen_deer', 'maetoad', 'melbear'] as const;
+const VALID_ENEMIES = ['lithkem_swallow', 'sulfolk', 'talwyrm', 'daefen_deer', 'maetoad', 'golnosar', 'melbear'] as const;
 type EnemyKey = typeof VALID_ENEMIES[number];
 
 const BAIT_TO_ENEMY: Record<string, EnemyKey> = {
@@ -193,6 +193,7 @@ const BAIT_TO_ENEMY: Record<string, EnemyKey> = {
   wyrm_bait:    'talwyrm',
   deer_bait:    'daefen_deer',
   toad_bait:    'maetoad',
+  tar_bait:     'golnosar',
   bear_bait:    'melbear',
 };
 const BAIT_ITEM_IDS = Object.keys(BAIT_TO_ENEMY);

--- a/src/tools/simulate.ts
+++ b/src/tools/simulate.ts
@@ -19,6 +19,13 @@ const ENEMIES_DIR = join(__dirname, '../../database/enemies');
 const MAX_ROUNDS  = 80;
 const N           = 5_000;
 
+// Sim approximation: real combat is spatial, so a target can dodge an aimed
+// attack by moving off the targeted tile. Without this roll the sim assumes
+// every aimed attack lands, which overstates damage from big aimed actions
+// like Fistar or Ursa Major.
+const AIM_HIT_CHANCE = 0.5;
+const aimedHits = (action: Action): boolean => !action.aimed || Math.random() < AIM_HIT_CHANCE;
+
 // ---- Types ----
 
 type EnemyData = {
@@ -105,8 +112,12 @@ function runBattle(pWeapon: Weapon, eData: EnemyData): BattleResult {
         const eChoice = chooseEnemyAction(eWeapon, enemy, pattern, eIdx);
         eIdx = eChoice.nextIdx;
 
-        // Crit: player attacks, enemy specials → attack_crit fires first
-        if (pChoice.category === 'attack' && eChoice.category === 'special' && pWeapon.attack_crit.length > 0) {
+        const playerHits = aimedHits(pChoice.action);
+        const enemyHits  = aimedHits(eChoice.action);
+
+        // Crit: player attacks, enemy specials → attack_crit fires first.
+        // Skipped if the player's main attack would miss its aim.
+        if (playerHits && pChoice.category === 'attack' && eChoice.category === 'special' && pWeapon.attack_crit.length > 0) {
             const ehpBefore = enemy.health;
             resolve_action(player, enemy, [pWeapon.attack_crit[0]]);
             damageToEnemy += ehpBefore - enemy.health;
@@ -115,12 +126,14 @@ function runBattle(pWeapon: Weapon, eData: EnemyData): BattleResult {
         // Player action
         const ehp = enemy.health;
         const php = player.health;
-        resolve_action(player, enemy, [pChoice.action]);
+        if (playerHits) resolve_action(player, enemy, [pChoice.action]);
+        else            player.apply_cost(pChoice.action);
         damageToEnemy  += Math.max(0, ehp - enemy.health);
         if (enemy.health <= 0) return { winner: 'player', rounds: round + 1, playerHpLeft: player.health, damageToEnemy, damageToPlayer };
 
         // Enemy action
-        resolve_action(enemy, player, [eChoice.action]);
+        if (enemyHits) resolve_action(enemy, player, [eChoice.action]);
+        else           enemy.apply_cost(eChoice.action);
         damageToPlayer += Math.max(0, php - player.health);
         if (player.health <= 0) return { winner: 'enemy', rounds: round + 1, playerHpLeft: 0, damageToEnemy, damageToPlayer };
 


### PR DESCRIPTION
## Summary

0.1.4 release. Highlights:

- **New enemy**: Golnosar (L4, 110 HP) — tar-pool DOT specialist. Tar Bait at the general store, drops Bottle of Tar (lumberjack) + Lifgem (enchanter, rare).
- **Card Deck** general-store item — recipe ingredient for Deck of Cards (and its Nodol upgrade).
- **Mobile**: hamburger sidebar drawer, battle board scales via `--cell-size` CSS var (44px on mobile). Tested down to 390px.
- **Keyboard combat**: arrow keys move, 1–9 picks action, Enter confirms/skips/returns to town. Hunt page accepts Enter on bait selection.
- **ALL buttons** restored on shop sell + crafting batch quantity.
- **Economy**: R/R_Max tier split (bulk period-doubling, valuables full chaos, baits stable convergence). Volume_Sensitivity cut 5–8× so trading actually moves r. Baits demand-responsive.
- **Renames**: `bear_teeth` → `melstone`, `diamond` → `lifgem` (diamond was never released; melstone needs DB migration).
- **Lore**: named the Chae emperor (Gustavus).
- **Discord changelog split** — condensed player-facing log at `docs/CHANGELOG_DISCORD.md` is what the version auto-announcer now reads.
- **Sim**: 50% aim-miss roll on aimed actions (sim-only) to compensate for spatial dodging the sim doesn't model.

Full detail in `docs/CHANGELOG.md` 0.1.4 section.

## Pre-deploy migration (REQUIRED on prod)

```sql
UPDATE "ShopItemState"   SET item_id='melstone' WHERE item_id='bear_teeth';
UPDATE "ShopTransaction" SET item_id='melstone' WHERE item_id='bear_teeth';
UPDATE "InventoryItem"   SET item_id='melstone' WHERE item_id='bear_teeth';
```
(Diamond → lifgem rename has no prod data since diamond never shipped.)

## Test plan

- [ ] Bait flow: buy tar bait at general store → hunt golnosar → loot bottle of tar + occasional lifgem
- [ ] Card deck: buy at general store → enchanter craft Deck of Cards consumes it
- [ ] Mobile: hamburger drawer toggles, battle board fits on phone-width viewport, action buttons tap-friendly
- [ ] Keyboard: arrow keys move in battle, 1–9 select actions, Enter confirms/skips
- [ ] Shop ALL buttons: sell-stack dumps full quantity, craft-max crafts up to budget cap
- [ ] Economy: confirm prices visibly shift after a few buy/sell cycles on a valuable
- [ ] Auto-announce: version bump triggers Discord update post reading from CHANGELOG_DISCORD.md
- [ ] Migration run on prod before bot starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)