### PR TITLE
0.1.5 — combat rewrite for teams, info pages, infra fixes

### DIFF
--- a/database/docs/about.md
+++ b/database/docs/about.md
@@ -1,0 +1,11 @@
+# About Legends of Apolis
+
+I first got the idea for Legends of Apolis back in 2014 when I found this out of the way chat room on pokemon showdown website called Battle Dome. It was a role playing game that was similar to pokemon, but different too and everything was run through the chat interface. It was also around the time we had just gotten graphing calculators for our math class and I was enamored by the TI Basic coding language, learning to make my own games on it. It wasn't too long before I was planning out my own Text based RPG with my own particular style.
+
+I wanted it to be unique with unconventional methods of progression and fun weapons that went outside the normal gamut of "sword! axe! dagger! bow!". I wrote out systems and characters and ideas but never had the time or skill to really make it real.
+
+As I went to college, the ideas never left my head, but I got busy with other things. I got better at programming but had less energy and time to work on passion projects. Starting a career did not help with that either. What a boon, though, because my creativity and experience were growing in the background. This iteration doesn't look exactly like the idea I had 14 years ago, but that's because it's better. It's more honed. Ideas and thoughts from other realms of my life have seeped in and affected things in subtle ways.
+
+The idea of the game revolving around a community is relatively new. I don't think I've ever played a game where the systems are designed to create player interaction in quite the way I've designed this game. It's a new idea and one I hope creates something beyond the game itself. In that same vein, I hope the community and all it's collective experiences help shape the game.
+
+Thank you for playing Legends of Apolis!

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -131,7 +131,7 @@ The **Bench** is where you turn materials into things. It splits into three page
 
 There are three professions: **Lumberjack (LJ)**, **Blacksmith (BS)**, and **Enchanter**. You can level each one from 1 to 10, with a combined cap of 30 across all three.
 
-The cost of a level depends on your **total** profession levels across all three. Your 1st level (in any profession) is cheap; your 30th — the last one to reach the cap — is expensive. The profession you put it into doesn't change the price.
+The cost of a level depends on your **total** profession levels across all three. Your 1st level (in any profession) is cheap; your 30th — the last one to reach the cap — is expensive. The profession you put it into doesn't change the price, even if it's a lower level than another profession.
 
 That means picking up a second or third profession late is costly, and specializing is the cheaper path. Other players are expected to fill the gaps via trade.
 
@@ -188,7 +188,7 @@ For per-weapon stats and the exact actions of every weapon, see the [Weapon Stat
 
 Quick reference. Click any term to jump to its section.
 
-**Big concepts**
+**Essentials**
 - [Korel](#currency-and-stats) — the standard currency.
 - [Weapon](#weapons) — your equipped loadout; determines stats and available actions.
 - [Profession](#professions) — Lumberjack, Blacksmith, or Enchanter. Combined cap of 30 levels.
@@ -196,7 +196,7 @@ Quick reference. Click any term to jump to its section.
 - [Bait](#hunting) — consumable that summons one specific enemy.
 - [Loot](#hunting) — drops rolled at end of a victorious battle.
 
-**Combat objects**
+**Combat**
 - [HP](#currency-and-stats) — survival pool. Reach 0 and you lose.
 - [Resource](#currency-and-stats) — per-weapon secondary stat (Stamina, Luck, etc.). Drives action costs.
 - [Action](#weapons) — one entry in a weapon's set. Has a type, damage type/subtype, field/value, cost, range, aimed/reactive, and (for duration) rounds.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -1,0 +1,170 @@
+# Currency and Stats
+
+**Korel** is the standard currency. Stamped with Emperor Gustavus's face. Earned by selling loot to shops and from battle rewards. Used to buy weapons, baits, materials, and upgrades.
+
+**Health (HP)** is your survival pool in a fight. Drops to zero, you lose the battle.
+
+**Resource** is a per-weapon secondary stat. Each weapon has its own — Stamina for an axe, Tar for a Golnosar — and most attacks cost some to use. Defensive actions usually restore it. Different weapons play very differently because of their resource rhythm.
+
+---
+
+# Combat Actions
+
+Every weapon has six action sets:
+
+- **Defend** and **Defend Crit**
+- **Attack** and **Attack Crit**
+- **Special** and **Special Crit**
+
+You pick one Defend, Attack, or Special each turn. The "Crit" variants are bonus actions that fire automatically when conditions are met (see Crits below).
+
+Actions come in eight types:
+
+- **Strike** — direct damage
+- **Block** — reduces incoming damage this turn
+- **Buff** — adds an effect that helps the user (e.g., boosts damage)
+- **Debuff** — adds an effect that hurts the target (e.g., reduces their damage)
+- **Heal** — restores HP
+- **DOT (Damage Over Time)** — ticks damage for several rounds after it lands
+- **Reflect** — sends a portion of incoming damage back at the attacker
+- **Shield** — soaks a fixed amount of damage over multiple turns
+
+**DOTs do not stack.** A new DOT replaces the existing one on the same target.
+
+**Field** is the damage roll table for an attack. `Field: [0, 1, 2, 5, 6, 7, 8]` means each hit picks one of those values at random. A wider range means swingier; a tighter range means predictable.
+
+**Range** is how far the action can reach measured in tiles (diagonals count as one step).
+
+**Aimed vs Reactive**:
+- **Aimed** — you pick a target tile before the attack fires. Lets you hit specific positions or save a powerful attack for a moment when the enemy is in range.
+- **Reactive** — fires automatically at the nearest valid target in range. Less control, more reliable.
+
+**Crits (`attack_crit`)** fire when you use an Attack and your target uses a Special on the same turn. The crit lands *before* the main attack. Defend Crit and Special Crit work analogously for those action types.
+
+---
+
+# Damage and Resistances
+
+Every action carries a **Damage Type** and a **Damage Subtype**.
+
+**Damage Types**
+- **Physical** — Sharp, Blunt, Poison
+- **Arcane** — Mental, Force
+- **Elemental** — Fire, Water, Earth, Wind, Plant
+
+Enemies have **Resistances** as multiplier scores against each type and subtype. Your action's type score and subtype score multiply together. The combined number doesn't directly multiply damage — it changes the *shape* of the roll:
+
+- Combined > 1.0 — **weakness** — roll 4 dice, take the highest (Hd4). Big variance, skews high.
+- Combined < 1.0 — **resist** — roll 2 dice, take the lowest (Ld2). Skews low.
+- Combined = 1.0 — **neutral** — single roll. Baseline.
+
+The combat log marks these with `[weakness — Hd4]` or `[resist — Ld2]` when active. Matching damage types to enemy weaknesses isn't always a guaranteed bonus, but it dramatically shifts the odds in your favor.
+
+---
+
+# The Battle
+
+Battles are turn-based on a small grid. Each turn unfolds in three phases:
+
+1. **Intent** — you and the enemy each choose an action.
+2. **Move** — both sides take their movement step.
+3. **Action** — Defends resolve first, then Attacks, then Specials. Within each sub-phase, the player resolves before the AI.
+
+You and your enemy share the board. Position matters: range, line of sight, and which tiles get blocked by obstacles all shape what's possible. The board includes **obstacles** — rolled randomly per hunt — that block both movement and aimed attacks. Diagonal moves can't slip between two obstacles that touch corners.
+
+DOTs tick at end of round. If a fight ends with both combatants dying to DOT damage on the same tick, the AI's DOT resolves first, then yours — death is checked between.
+
+---
+
+# Hunting
+
+Hunts happen on the **Hunt** page. Each hunt costs one **bait** from the General Store, and each bait summons one specific enemy:
+
+| Bait | Enemy |
+|---|---|
+| Swallow Bait | Lithkem Swallow |
+| Sulfolk Bait | Sulfolk |
+| Wyrm Bait | Talwyrm |
+| Deer Bait | Daefen Deer |
+| Toad Bait | Maetoad |
+| Tar Bait | Golnosar |
+| Bear Bait | Melbear |
+
+**Loot** is rolled at the end of a victorious battle, not per turn. Each enemy has a drop table — see the **Enemies** info page for the exact roll tables.
+
+Each hunt rolls a fresh board layout: 2–6 obstacles placed randomly in the open zone. The tutorial board is fixed.
+
+---
+
+# Town Shops
+
+Sulku'it has four shops. Each one buys back items at a sell price and stocks goods at a buy price.
+
+- **General Store** (Dolan) — baits, miscellaneous valuables.
+- **Blacksmith** (Kethalis) — talamite materials, metal weapons, blacksmith components.
+- **Lumberjack** (Vetha) — sulwood materials, wood weapons, lumber components.
+- **Enchanting Shop** (Lomis) — enchanting reagents, arcane weapons, valuable gemstones.
+
+**Prices move with the market.** Shops respond to player trading: heavy buying pushes prices up, heavy selling pushes them down. Some items (valuables) swing harder; bulk materials shift more slowly. Idle items drift back toward their baseline.
+
+If a shop's shelf is full of an item, it stops buying that item until stock clears. Shops dump excess stock on their own schedule to keep things flowing.
+
+---
+
+# The Bench
+
+The **Bench** is where you turn materials into things. It splits into three pages, one per profession:
+
+- **Crafting** — combine materials and components into finished weapons, intermediates, and enchanting reagents. The recipe is fixed; you provide the inputs.
+- **Upgrading** — spend tier-2 or tier-3 material on a weapon you own to permanently boost its stats. Each profession has its own upgrade budget per weapon.
+- **Enchanting** — apply an enchant to one of a weapon's three enchant slots. Enchants change an action's damage subtype (minor) or its full damage type and subtype (major). Three enchant slots per weapon, one enchant per action, permanent.
+
+---
+
+# Professions
+
+There are three professions: **Lumberjack (LJ)**, **Blacksmith (BS)**, and **Enchanter**. You can level each one from 1 to 10. Total combined level is capped at 30, so leveling all three to max is possible but takes work.
+
+| Profession | What it crafts | What it upgrades |
+|---|---|---|
+| Lumberjack | Wood and hybrid weapons | Any weapon with a wood component |
+| Blacksmith | Metal weapons | Talamite-only weapons (no wood handle) |
+| Enchanter | Enchanting reagents and arcane weapons | All weapons (via enchants) |
+
+Hybrid weapons (Sword (Talamite), Axe (Talamite), Shovel (Talamite)) can be upgraded by **either** LJ or BS — cross-profession collaboration is intentional.
+
+Each profession level grants either a new recipe or a bigger upgrade budget. See the **Professions** info page for the full per-level breakdown.
+
+---
+
+# Trading
+
+You can trade with another player at any time. From the **Trade** page, search a partner by character name, and you'll both land in a shared trade view.
+
+Both sides drop items, weapons, and **korel** into their offer panel. Each side must **lock in** their offer (no further changes), then both must **confirm**. The transfer happens atomically — if anything goes wrong, nobody loses anything.
+
+Equipped weapons can't be traded. Unequip first if you want to send one across.
+
+---
+
+# The Pages
+
+The sidebar groups everything you'll touch into four areas.
+
+**Top group** (your character and the world):
+- **Character** — your sprite, stats, profession levels.
+- **Inventory** — your items and weapons. Equip weapons from here.
+- **Hunt** — pick a bait, start a battle.
+- **Trade** — open a trade session with another player.
+
+**Bench** (production):
+- **Crafting**, **Upgrading**, **Enchanting** — described above.
+
+**Town** (the four shops): General Store, Blacksmith, Lumberjack, Enchanting Shop.
+
+**Info** (reference, no game state changes):
+- **Professions** — per-level recipe and budget breakdown.
+- **Enemies** — drop tables for every enemy.
+- **Weapon Stats** — action stats and damage fields for every weapon.
+- **Lore** — the world, its peoples, the town.
+- **Reference** — this page.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -4,7 +4,7 @@
 
 **Health (HP)** is your survival pool in a fight. Drops to zero, you lose the battle.
 
-**Resource** is a per-weapon secondary stat. Each weapon has its own — Stamina for an axe, Energy for a deck of cards — and most attacks cost some to use. Most weapons have a dedicated action to restore it. Different weapons play very differently because of their resource rhythm.
+**Resource** is a per-weapon secondary stat. Each weapon has its own — Stamina for an axe, Luck for a deck of cards — and most attacks cost some to use. Most weapons have a dedicated action to restore it. Different weapons play very differently because of their resource rhythm.
 
 ---
 
@@ -16,14 +16,14 @@ Every weapon has three action sets, plus an attack crit:
 - **Attack** and **Attack Crit**
 - **Special**
 
-You pick one Defend, Attack, or Special each turn. The Attack Crit is a bonus action that fires automatically when the conditions are met (see Crits below).
+You pick one Defend, Attack, or Special each turn. The **Attack Crit** is a bonus action that fires automatically when conditions are met (see Crits below).
 
 Actions come in eight types. Some take effect immediately, others apply a duration over several rounds. **Duration effects never stack** — applying a new one replaces the existing one on the same target.
 
 | Type | Effect | Duration |
 |---|---|---|
 | **Strike** | Direct damage | Immediate |
-| **Block** | Reduces incoming damage this turn | Immediate (this turn only) |
+| **Block** | Reduces incoming damage this turn | Immediate |
 | **Buff** | Boosts the user's damage | Duration |
 | **Debuff** | Reduces the target's damage | Duration |
 | **Heal** | Restores HP | Immediate |
@@ -31,15 +31,15 @@ Actions come in eight types. Some take effect immediately, others apply a durati
 | **Reflect** | Sends a portion of incoming damage back | Duration |
 | **Shield** | Soaks a fixed amount of damage | Duration |
 
-**Field** is the roll table for any value that varies — damage on a Strike, damage per tick on a DOT, even shield/block values. `Field: [0, 1, 2, 5, 6, 7, 8]` means each use picks one of those values at random. A wider range is swingier; a tighter range is more predictable.
+**Field** is the roll table for any value that varies — usually the damage on a Strike or DOT tick. `Field: [0, 1, 2, 5, 6, 7, 8]` means each use picks one of those values at random. A wider range is swingier; a tighter range is more predictable.
 
 **Range** is how far the action can reach, measured in tiles (diagonals count as one step).
 
 **Aimed vs Reactive**:
-- **Aimed** — you pick a target tile before the attack fires. Less reliable, because the target can move off the tile.
+- **Aimed** — you pick a target tile before the attack fires. Less reliable, requires prediction.
 - **Reactive** — fires automatically at the nearest valid target in range. More reliable.
 
-**Crits** — `attack_crit` fires when you use an Attack and your target uses a Special on the same turn. The crit lands **after** the main attack.
+**Attack Crit** fires when you use an Attack and your target uses a Special on the same turn. The crit lands **after** the main attack.
 
 ---
 
@@ -66,14 +66,19 @@ The combat log marks these with `[weakness — Hd4]` or `[resist — Ld2]` when 
 
 # The Battle
 
-Battles are turn-based on a small grid. You and your enemy submit your choices each turn, then resolution runs in two phases:
+Battles are turn-based on a small grid against an enemy from the [Enemies](/app/enemies) roster. Each turn unfolds in three phases:
 
-1. **Move phase** — both sides execute their movement step.
-2. **Action phase** — Defends resolve first, then Attacks, then Specials. Within each sub-phase, the player resolves before the AI.
+1. **Intent phase** — you and the enemy each pick a move target and an action for the turn.
+2. **Move phase** — both sides execute their movement step.
+3. **Action phase** — actions resolve in a fixed order:
+   - **Defends**
+   - **Attacks** (including Attack Crit triggers)
+   - **Specials**
+   - **DOT ticks** (end of round)
+
+**Within each action sub-phase, the player resolves before the AI — except DOT ticks, where the AI ticks first.** The battle ends the moment any character reaches 0 HP — they're the loser, even if a tick on the same round would have killed both.
 
 Position matters: range, line of sight, and which tiles get blocked by **obstacles** all shape what's possible. Obstacles are rolled randomly per hunt and block both movement and aimed attacks. Diagonal moves can't slip between two obstacles that touch corners.
-
-**The battle ends the moment any character reaches 0 HP — they're the loser.** DOTs tick at end of round and are checked the same way: whoever drops first is the loser.
 
 ---
 
@@ -118,7 +123,7 @@ The **Bench** is where you turn materials into things. It splits into three page
 
 - **Crafting** — combine materials and components into finished weapons, intermediates, and enchanting reagents.
 - **Upgrading** — spend tier-2 or tier-3 material on a weapon you own to permanently boost its stats. Each profession has its own upgrade budget per weapon.
-- **Enchanting** — apply an enchant to one of a weapon's three enchant slots. A **minor** enchant changes the **Damage Subtype** of one action; a **major** enchant changes both **Damage Type** and **Damage Subtype** (and adds a small bonus). Three enchant slots per weapon, one enchant per action, permanent.
+- **Enchanting** — apply an enchant to one of a weapon's three enchant slots. A **minor** enchant changes the **Damage Subtype** of one action and adds a small bonus. A **major** enchant changes both **Damage Type** and **Damage Subtype** and adds a large bonus (+3). Three enchant slots per weapon, one enchant per action, permanent.
 
 ---
 
@@ -132,7 +137,7 @@ There are three professions: **Lumberjack (LJ)**, **Blacksmith (BS)**, and **Enc
 | Blacksmith | Metal weapons | Any weapon containing talamite |
 | Enchanter | Enchanter-tree weapons (spellbook, wand, kustaff, deck of cards, mental cage) | Enchanter-tree weapons |
 
-Hybrid weapons (Sword (Talamite), Axe (Talamite), Shovel (Talamite)) have both wood and talamite parts, so **both** LJ and BS can upgrade them — cross-profession collaboration is intentional.
+Hybrid weapons (Sword (Talamite), Axe (Talamite), Shovel (Talamite)) have both wood and talamite parts, so **both** LJ and BS can upgrade them.
 
 Enchanting is a separate system from upgrades. Any profession's weapon can receive enchants (apply via the Enchanting page above).
 
@@ -147,3 +152,55 @@ You can trade with another player at any time. From the **Trade** page, search a
 Both sides drop items, weapons, and korel into their offer panel. Each side must lock in their offer (no further changes), then both must confirm. The transfer happens atomically — if anything goes wrong, nobody loses anything.
 
 Equipped weapons can't be traded.
+
+---
+
+# Glossary
+
+Quick reference. Click any term to jump to its section.
+
+**Currency and stats**
+- [Korel](#currency-and-stats) — the standard currency.
+- [HP](#currency-and-stats) — health pool; drops to 0, you lose.
+- [Resource](#currency-and-stats) — per-weapon secondary stat (Stamina, Luck, Tar, etc.).
+
+**Combat actions**
+- [Strike](#combat-actions) — direct damage.
+- [Block](#combat-actions) — reduces this turn's incoming damage.
+- [Buff](#combat-actions) — boosts user's damage for a duration.
+- [Debuff](#combat-actions) — reduces target's damage for a duration.
+- [Heal](#combat-actions) — restores HP.
+- [DOT](#combat-actions) — Damage Over Time; ticks each round.
+- [Reflect](#combat-actions) — returns a portion of incoming damage.
+- [Shield](#combat-actions) — soaks a fixed amount of damage over multiple turns.
+- [Field](#combat-actions) — the roll table for a variable value.
+- [Range](#combat-actions) — reach in tiles (diagonal counts as one).
+- [Aimed](#combat-actions) — pick a tile to fire at.
+- [Reactive](#combat-actions) — fires at nearest valid target automatically.
+- [Attack Crit](#combat-actions) — bonus action when your Attack meets enemy Special.
+- [Duration](#combat-actions) — multi-round effects; never stack.
+
+**Damage**
+- [Damage Type](#damage-and-resistances) — Physical / Arcane / Elemental.
+- [Damage Subtype](#damage-and-resistances) — Sharp, Blunt, Mental, Force, Fire, Water, Earth, Wind, Plant.
+- [Weakness](#damage-and-resistances) — Hd4 roll (skews high).
+- [Resist](#damage-and-resistances) — Ld2 roll (skews low).
+- [Neutral](#damage-and-resistances) — 1d roll (baseline).
+
+**Battle**
+- [Intent phase](#the-battle) — choose your move + action.
+- [Move phase](#the-battle) — both sides step.
+- [Action phase](#the-battle) — Defends → Attacks → Specials → DOT ticks.
+- [Obstacle](#the-battle) — blocks movement and aimed attacks.
+
+**Hunt and economy**
+- [Bait](#hunting) — consumable that summons one enemy.
+- [Loot](#hunting) — drops rolled on victory.
+- [Bench](#the-bench) — your production area.
+- [Crafting](#the-bench), [Upgrading](#the-bench), [Enchanting](#the-bench) — Bench activities.
+- [Minor enchant](#the-bench) — changes subtype, small bonus.
+- [Major enchant](#the-bench) — changes type + subtype, +3 bonus.
+
+**Professions**
+- [Lumberjack](#professions), [Blacksmith](#professions), [Enchanter](#professions).
+- [Hybrid weapon](#professions) — wood + talamite parts; both LJ and BS can upgrade.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -42,13 +42,12 @@ Actions come in eight types. Some take effect immediately, others apply a durati
 
 **Attack Crit** fires when you use an Attack and your target uses a Special on the same turn. The crit lands **after** the main attack.
 
-**How damage adds up.** When you land a Strike, the rolled damage is adjusted by your active Buff (added) and Debuff (subtracted), then reduced by the target's Block and Shield. Final damage can't go below 0.
+**Damage calculation.** When a Strike lands, the rolled damage is adjusted by the attacker's active Buff (added) and Debuff (subtracted), then reduced by the target's Block and Shield. Final damage cannot go below 0.
 
-A few details worth knowing:
-- **Buff and Debuff are mutually exclusive on the same target.** Applying one clears the other — you can't be both buffed and debuffed at once.
-- **Block lasts only the current round.** It resets to 0 at end of round, so you have to re-apply it each turn you want it.
-- **Shield reduces damage every round for its duration.** It's not a damage pool that depletes; the value stays the same each round until the duration ends.
-- **Reflect fires on any incoming Strike**, regardless of how much damage landed (even 0). It sends a flat amount back.
+- **Buff and Debuff are mutually exclusive on the same target.** Applying one clears the other.
+- **Block resets at end of round.** It must be re-applied each round.
+- **Shield is not a depleting pool.** Its value subtracts from incoming damage each round for the duration.
+- **Reflect fires on any incoming Strike** regardless of damage landed, and sends a flat amount back.
 
 ---
 

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -42,11 +42,9 @@ Actions come in eight types. Some take effect immediately, others apply a durati
 
 **Attack Crit** fires when you use an Attack and your target uses a Special on the same turn. The crit lands **after** the main attack.
 
-**How damage adds up.** When a Strike lands, the final damage is one arithmetic step:
+**How damage adds up.** When you land a Strike, the rolled damage is adjusted by your active Buff (added) and Debuff (subtracted), then reduced by the target's Block and Shield. Final damage can't go below 0.
 
-`damage = max(0, roll + attacker's Buff − attacker's Debuff − target's Block − target's Shield)`
-
-Final damage is never below zero. A few non-obvious rules:
+A few details worth knowing:
 - **Buff and Debuff are mutually exclusive on the same target.** Applying one clears the other — you can't be both buffed and debuffed at once.
 - **Block lasts only the current round.** It resets to 0 at end of round, so you have to re-apply it each turn you want it.
 - **Shield reduces damage every round for its duration.** It's not a damage pool that depletes; the value stays the same each round until the duration ends.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -112,7 +112,7 @@ Hunts happen on the **Hunt** page. Each hunt costs one bait from the General Sto
 
 Each hunt rolls a fresh board layout with obstacles placed randomly in the open zone.
 
-**A bait occasionally pulls a second enemy of the same type** — roughly one in forty hunts. Both must be defeated, each drops loot, and the combat log distinguishes them with an `A` / `B` suffix. Their action patterns start offset so they don't move in sync.
+**A bait occasionally pulls a second enemy of the same type** — about a 2.3% chance per hunt. Both must be defeated, each drops loot, and the combat log distinguishes them with an `A` / `B` suffix. Their action patterns start offset so they don't move in sync.
 
 ---
 

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -121,7 +121,7 @@ If a shop's shelf is full of an item, it stops buying that item until stock clea
 
 The **Bench** is where you turn materials into things. It splits into three pages, one per profession:
 
-- [**Crafting**](/app/crafting) — combine materials and components into finished weapons, intermediates, and enchanting reagents.
+- [**Crafting**](/app/crafting) — combine materials and components into finished weapons, intermediates, and enchanting reagents. Weapons crafted from higher-tier components come with bonuses baked in (see [Items](#items)).
 - [**Upgrading**](/app/upgrade) — spend tier-2 or tier-3 material on a weapon you own to permanently boost its stats. Each profession has its own upgrade budget per weapon.
 - [**Enchanting**](/app/enchant) — apply an enchant to one of a weapon's three enchant slots. A **minor** enchant changes the **Damage Subtype** of one action and adds a small bonus. A **major** enchant changes both **Damage Type** and **Damage Subtype** and adds a large bonus (+3). Three enchant slots per weapon, one enchant per action, permanent.
 
@@ -184,6 +184,25 @@ For per-weapon stats and the exact actions of every weapon, see the [Weapon Stat
 
 ---
 
+# Items
+
+Every item in your inventory has a type:
+
+- **Material** — raw or processed crafting inputs (sulwood, talamite, hiruos, treated sulwood, hardwood, alloy, nodol, etc.). Used at the Bench.
+- **Component** — a crafted intermediate combined into a weapon (sword hilt, axe head, wand base, etc.). All components are also materials.
+- **Valuable** — loot from enemies meant for selling (swallow feather, venison, melstone, lifgem, etc.). Generally not used in crafting.
+- **Consumable** — spent on use. Baits are the main consumables — one is consumed per hunt.
+
+**Components have tiers**. Most weapons have a base recipe plus one or two higher-tier variants:
+
+- **Tier-1** — the base recipe. Uses raw or unprocessed material. No bundled bonus.
+- **Tier-2** — uses tier-2 components (treated sulwood, talamite, hiruos). The crafted weapon comes with a free **+1 attack** baked in. Unlocks at profession level 2–3.
+- **Tier-3** — uses tier-3 components (hardwood, alloy, nodol). The crafted weapon comes with **+1 defend, +1 attack, +1 special** baked in. Unlocks at profession level 7.
+
+These free bonuses don't count against your [upgrade budget](#the-bench) — they're part of the recipe. So crafting a hardwood quarterstaff gives you a quarterstaff that's already +1/+1/+1 without spending any upgrade points.
+
+---
+
 # Glossary
 
 Quick reference. Click any term to jump to its section.
@@ -243,3 +262,10 @@ Quick reference. Click any term to jump to its section.
 - [Minor enchant](#the-bench) — changes Damage Subtype, small bonus.
 - [Major enchant](#the-bench) — changes Damage Type and Subtype, +3 bonus.
 - [Hybrid weapon](#professions) — has wood and talamite parts; both LJ and BS can upgrade.
+
+**Items**
+- [Material](#items) — raw or processed crafting input.
+- [Component](#items) — crafted intermediate combined into a weapon (sword hilt, axe head, etc.). All components are also materials.
+- [Valuable](#items) — loot meant for selling.
+- [Consumable](#items) — single-use item (baits are the main example).
+- [Tier-1 / Tier-2 / Tier-3](#items) — component tiers. Tier-2 weapons get +attack baked in; tier-3 get +defend/+attack/+special.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -76,7 +76,7 @@ The combat log marks these with `[weakness — Hd4]` or `[resist — Ld2]` when 
 
 Battles are turn-based on a grid against one or more enemies from the [Enemies](/app/enemies) roster. Every combatant begins at **full HP and full Resource**.
 
-At the start of every battle, every combatant rolls for **initiative** — a random score that decides turn order for the whole fight. Lighter weapons (lower **Weight**) roll higher on average and act earlier. The rolls appear at the top of the combat log in the order combatants will act. On a rare tied roll, the player wins against an NPC; otherwise it's a coin flip.
+At the start of every battle, every combatant rolls for **initiative** — a random score that decides turn order for the whole fight. Lighter weapons (lower **Weight**) roll higher on average and act earlier. The rolls appear at the top of the combat log in the order combatants will act. On a tie, the player wins against an NPC; otherwise it's a coin flip.
 
 Each turn unfolds in three phases:
 
@@ -112,7 +112,7 @@ Hunts happen on the **Hunt** page. Each hunt costs one bait from the General Sto
 
 Each hunt rolls a fresh board layout with obstacles placed randomly in the open zone.
 
-**Occasionally a bait pulls a second enemy** of the same type — roughly one hunt in forty. Two enemies share the board and the combat log distinguishes them with an `A` / `B` suffix (e.g. `Lithkem Swallow A`, `Lithkem Swallow B`). Both must be defeated to win; each rolls its own loot table independently. Each enemy starts at a random position in its action pattern, so identical enemies don't telegraph identical actions on turn 1.
+**A bait occasionally pulls a second enemy of the same type** — roughly one in forty hunts. Both must be defeated, each drops loot, and the combat log distinguishes them with an `A` / `B` suffix. Their action patterns start offset so they don't move in sync.
 
 ---
 

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -1,6 +1,6 @@
 # Currency and Stats
 
-**Korel** is the standard currency. Earned by selling loot to shops and from battle rewards. Used to buy weapons, baits, and materials.
+**Korel** is the standard currency. Earned by selling loot to shops. Used to buy weapons, baits, and materials.
 
 **Health (HP)** is your survival pool in a fight. Drops to zero, you lose the battle.
 
@@ -38,8 +38,11 @@ Actions come in eight types. Some take effect immediately, others apply a durati
 **Aimed vs Reactive**:
 - **Aimed** — you pick a target tile before the attack fires. Less reliable, requires prediction.
 - **Reactive** — fires automatically at the nearest valid target in range. More reliable.
+- **Self-targeting** — Heal and Buff actions automatically target the user (you), not an enemy. You don't pick a tile for them.
 
 **Attack Crit** fires when you use an Attack and your target uses a Special on the same turn. The crit lands **after** the main attack.
+
+**Damage modifier order.** When several effects are active on a turn, they apply to the raw damage roll in a fixed order: **Buffs** (boost the attacker) → **Debuffs** (reduce the attacker) → **Blocks** (subtract from incoming damage) → **Shields** (soak remaining damage). The combat log shows each step so you can see how the final number was reached.
 
 ---
 
@@ -66,7 +69,9 @@ The combat log marks these with `[weakness — Hd4]` or `[resist — Ld2]` when 
 
 # The Battle
 
-Battles are turn-based on a small grid against an enemy from the [Enemies](/app/enemies) roster. Each turn unfolds in three phases:
+Battles are turn-based on a small grid against an enemy from the [Enemies](/app/enemies) roster. You start each battle at **full HP and full Resource** — no need to warm up before using a Special.
+
+Each turn unfolds in three phases:
 
 1. **Intent phase** — you and the enemy each pick a move target and an action for the turn.
 2. **Move phase** — both sides execute their movement step.
@@ -179,6 +184,8 @@ An **Action** has:
 - **Range** — how far it reaches in tiles.
 - **Aimed or Reactive** — targeting mode.
 - **Rounds** — for duration actions (DOT, Buff, Debuff, Reflect, Shield), how many rounds the effect lasts.
+
+**Each weapon you own is its own instance.** If you craft two Quarterstaffs, they're separate items — upgrades and enchants on one don't carry over to the other. You can keep a fresh "spare" alongside a heavily-upgraded main weapon if you want.
 
 For per-weapon stats and the exact actions of every weapon, see the [Weapon Stats](/app/weapon-stats) info page.
 

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -4,7 +4,7 @@
 
 **Health (HP)** is your survival pool in a fight. Drops to zero, you lose the battle.
 
-**Resource** is a per-weapon secondary stat. Each weapon has its own — Stamina for an axe, Luck for a deck of cards — and most attacks cost some to use. Most weapons have a dedicated action to restore it. Different weapons play very differently because of their resource rhythm.
+**Resource** is a per-weapon secondary stat. Each weapon has its own — Stamina for an axe, Luck for a deck of cards — and most attacks cost some to use. Most weapons have a dedicated action to restore it.
 
 ---
 
@@ -31,14 +31,14 @@ Actions come in eight types. Some take effect immediately, others apply a durati
 | **Reflect** | Sends a flat amount back any round you take a Strike | Duration |
 | **Shield** | Subtracts a flat amount from damage you take each round | Duration |
 
-**Field** is the roll table for any value that varies — usually the damage on a Strike or DOT tick. `Field: [0, 1, 2, 5, 6, 7, 8]` means each use picks one of those values at random. A wider range is swingier; a tighter range is more predictable.
+**Field** is the roll table for any value that varies — usually the damage on a Strike or DOT tick. `Field: [0, 1, 2, 5, 6, 7, 8]` means each use picks one of those values at random.
 
 **Range** is how far the action can reach, measured in tiles (diagonals count as one step).
 
 **Aimed vs Reactive**:
 - **Aimed** — you pick a target tile before the attack fires. Less reliable, requires prediction.
 - **Reactive** — fires automatically at the nearest valid target in range. More reliable.
-- **Self-targeting** — Heal and Buff actions automatically target the user (you), not an enemy. You don't pick a tile for them.
+- **Self-targeting** — Heal and Buff actions target the user automatically; no tile selection.
 
 **Attack Crit** fires when you use an Attack and your target uses a Special on the same turn. The crit lands **after** the main attack.
 
@@ -68,13 +68,13 @@ Enemies have **Resistances** against each type and subtype. Your action's type a
 | **Resist** | **Ld2** | Roll 2 dice, take the lowest. Skews low. |
 | **Neutral** | **1d** | Single roll. Baseline. |
 
-The combat log marks these with `[weakness — Hd4]` or `[resist — Ld2]` when active. Matching damage types to enemy weaknesses isn't a guaranteed bonus, but it dramatically shifts the odds in your favor.
+The combat log marks these with `[weakness — Hd4]` or `[resist — Ld2]` when active. Type matchups shift the roll distribution; they don't apply a flat damage multiplier.
 
 ---
 
 # The Battle
 
-Battles are turn-based on a small grid against an enemy from the [Enemies](/app/enemies) roster. You start each battle at **full HP and full Resource** — no need to warm up before using a Special.
+Battles are turn-based on a small grid against an enemy from the [Enemies](/app/enemies) roster. Both combatants begin at **full HP and full Resource**.
 
 Each turn unfolds in three phases:
 
@@ -86,9 +86,9 @@ Each turn unfolds in three phases:
    - **Special actions**
    - **DOT ticks** (end of round)
 
-**Within each action sub-phase, the player resolves before the AI — except DOT ticks, where the AI ticks first.** The battle ends the moment any character reaches 0 HP — they're the loser, even if a tick on the same round would have killed both.
+Within each action sub-phase, the player resolves before the AI — **except DOT ticks, where the AI ticks first**. The battle ends the moment any character reaches 0 HP — they are the loser. If both would drop from ticks on the same round, whichever reaches 0 first loses.
 
-Position matters: range, line of sight, and which tiles get blocked by **obstacles** all shape what's possible. Obstacles are rolled randomly per hunt and block both movement and aimed attacks. Diagonal moves can't slip between two obstacles that touch corners.
+Range, line of sight, and **obstacles** all affect movement and targeting. Obstacles are rolled randomly per hunt and block both movement and aimed attacks. Diagonal moves cannot pass between two obstacles that touch corners.
 
 ---
 
@@ -123,13 +123,13 @@ Sulku'it has four shops. Each one buys back items at a sell price and stocks goo
 
 Prices move with the market. Shops respond to player trading: heavy buying pushes prices up, heavy selling pushes them down. Some items (valuables) swing harder; bulk materials shift more slowly. Idle items drift back toward their baseline.
 
-If a shop's shelf is full of an item, it stops buying that item until stock clears. Shops dump excess stock on their own schedule to keep things flowing.
+If a shop's shelf is full of an item, it stops buying that item until stock clears. Shops dump excess stock on their own schedule.
 
 ---
 
 # The Bench
 
-The **Bench** is where you turn materials into things. It splits into three pages, one per profession:
+The **Bench** is where materials become items, weapons, and enchants. It splits into three pages, one per profession:
 
 - [**Crafting**](/app/crafting) — combine materials and components into finished weapons, intermediates, and enchanting reagents. Weapons crafted from higher-tier components come with bonuses baked in (see [Items](#items)).
 - [**Upgrading**](/app/upgrade) — spend tier-2 or tier-3 material on a weapon you own to permanently boost its stats. Each profession has its own upgrade budget per weapon.
@@ -143,7 +143,7 @@ There are three professions: **Lumberjack (LJ)**, **Blacksmith (BS)**, and **Enc
 
 The cost of a level depends on your **total** profession levels across all three. Your 1st level (in any profession) is cheap; your 30th — the last one to reach the cap — is expensive. The profession you put it into doesn't change the price, even if it's a lower level than another profession.
 
-That means picking up a second or third profession late is costly, and specializing is the cheaper path. Other players are expected to fill the gaps via trade.
+Picking up a second or third profession late costs more total korel and materials than specializing. Players are expected to trade to cover gaps in their own professions.
 
 You raise profession levels on your [Character](/app/character) page.
 
@@ -165,7 +165,7 @@ Each profession level grants either a new recipe or a bigger upgrade budget. See
 
 You can trade with another player at any time. From the **Trade** page, search a partner by character name and you'll both land in a shared trade view.
 
-Both sides drop items, weapons, and korel into their offer panel. Each side must lock in their offer (no further changes), then both must confirm. The transfer happens atomically — if anything goes wrong, nobody loses anything.
+Both sides drop items, weapons, and korel into their offer panel. Each side must lock in their offer (no further changes), then both must confirm. The transfer is atomic — if validation fails, no items move.
 
 Equipped weapons can't be traded.
 
@@ -173,7 +173,7 @@ Equipped weapons can't be traded.
 
 # Weapons
 
-Your equipped **Weapon** sets your stats and dictates what actions are available in a fight. Different weapons play very differently — different HP totals, different resource rhythms, different action mixes.
+Your equipped **Weapon** sets your stats and dictates what actions are available in a fight. Weapons differ in HP, Resource, and action mix.
 
 A weapon has:
 - **HP** — the survival pool you fight with. Different weapons have different HP totals.
@@ -190,7 +190,7 @@ An **Action** has:
 - **Aimed or Reactive** — targeting mode.
 - **Rounds** — for duration actions (DOT, Buff, Debuff, Reflect, Shield), how many rounds the effect lasts.
 
-**Each weapon you own is its own instance.** If you craft two Quarterstaffs, they're separate items — upgrades and enchants on one don't carry over to the other. You can keep a fresh "spare" alongside a heavily-upgraded main weapon if you want.
+**Each weapon you own is its own instance.** Crafting two Quarterstaffs produces two separate items; upgrades and enchants on one do not carry over to the other.
 
 For per-weapon stats and the exact actions of every weapon, see the [Weapon Stats](/app/weapon-stats) info page.
 
@@ -210,7 +210,7 @@ Every item in your inventory has a type:
 - **Tier-2 recipes** — use tier-2 components (treated sulwood, talamite, hiruos). The crafted weapon comes with **+1 attack** baked in. The three starting weapons each have a tier-2 variant: **Quarterstaff (Treated)** at LJ level 2, **Dagger (Talamite)** at BS level 2, and **Spellbook (Hiruos)** at EN level 2.
 - **Tier-3 recipes** — use tier-3 components (hardwood, alloy, nodol). The crafted weapon comes with **+1 defend, +1 attack, +1 special** baked in. Every weapon has a tier-3 variant, unlocking at profession level 7.
 
-These baked-in bonuses don't count against your [upgrade budget](#the-bench) — they're part of the recipe. So crafting a hardwood quarterstaff gives you a +1/+1/+1 quarterstaff without spending any upgrade points.
+These baked-in bonuses do not count against the [upgrade budget](#the-bench) — they are part of the recipe. A hardwood quarterstaff arrives at +1/+1/+1 with no upgrade points spent.
 
 See the [Professions](/app/professions) info page for the full list of which recipes are available at each level.
 

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -106,10 +106,10 @@ Each hunt rolls a fresh board layout: 2–6 obstacles placed randomly in the ope
 
 Sulku'it has four shops. Each one buys back items at a sell price and stocks goods at a buy price.
 
-- **General Store** (Dolan) — baits, miscellaneous valuables.
-- **Blacksmith** (Kethalis) — talamite materials, metal weapons, blacksmith components.
-- **Lumberjack** (Vetha) — sulwood materials, wood weapons, lumber components.
-- **Enchanting Shop** (Lomis) — enchanting reagents, arcane weapons, valuable gemstones.
+- [**General Store**](/app/shop/general_store) (Dolan) — baits, miscellaneous valuables.
+- [**Blacksmith**](/app/shop/blacksmith) (Kethalis) — talamite materials, metal weapons, blacksmith components.
+- [**Lumberjack**](/app/shop/lumberjack) (Vetha) — sulwood materials, wood weapons, lumber components.
+- [**Enchanting Shop**](/app/shop/enchanting_shop) (Lomis) — enchanting reagents, arcane weapons, valuable gemstones.
 
 Prices move with the market. Shops respond to player trading: heavy buying pushes prices up, heavy selling pushes them down. Some items (valuables) swing harder; bulk materials shift more slowly. Idle items drift back toward their baseline.
 
@@ -121,15 +121,17 @@ If a shop's shelf is full of an item, it stops buying that item until stock clea
 
 The **Bench** is where you turn materials into things. It splits into three pages, one per profession:
 
-- **Crafting** — combine materials and components into finished weapons, intermediates, and enchanting reagents.
-- **Upgrading** — spend tier-2 or tier-3 material on a weapon you own to permanently boost its stats. Each profession has its own upgrade budget per weapon.
-- **Enchanting** — apply an enchant to one of a weapon's three enchant slots. A **minor** enchant changes the **Damage Subtype** of one action and adds a small bonus. A **major** enchant changes both **Damage Type** and **Damage Subtype** and adds a large bonus (+3). Three enchant slots per weapon, one enchant per action, permanent.
+- [**Crafting**](/app/crafting) — combine materials and components into finished weapons, intermediates, and enchanting reagents.
+- [**Upgrading**](/app/upgrade) — spend tier-2 or tier-3 material on a weapon you own to permanently boost its stats. Each profession has its own upgrade budget per weapon.
+- [**Enchanting**](/app/enchant) — apply an enchant to one of a weapon's three enchant slots. A **minor** enchant changes the **Damage Subtype** of one action and adds a small bonus. A **major** enchant changes both **Damage Type** and **Damage Subtype** and adds a large bonus (+3). Three enchant slots per weapon, one enchant per action, permanent.
 
 ---
 
 # Professions
 
 There are three professions: **Lumberjack (LJ)**, **Blacksmith (BS)**, and **Enchanter**. You can level each one from 1 to 10. Total combined level is capped at 30 — that's enough to max two and leave one at 10, or spread your levels more evenly. The cap means specializing is encouraged: you can't be the master of everything, and other players are expected to fill the gaps via trade.
+
+You raise profession levels on your [Character](/app/character) page.
 
 | Profession | What it crafts | What it upgrades |
 |---|---|---|
@@ -152,6 +154,29 @@ You can trade with another player at any time. From the **Trade** page, search a
 Both sides drop items, weapons, and korel into their offer panel. Each side must lock in their offer (no further changes), then both must confirm. The transfer happens atomically — if anything goes wrong, nobody loses anything.
 
 Equipped weapons can't be traded.
+
+---
+
+# Weapons
+
+A **Weapon** is the centerpiece of your loadout. The weapon you have equipped determines your stats and what actions you can take in a battle.
+
+A weapon has:
+- **HP** — the survival pool you fight with. Different weapons have different HP totals.
+- **Resource** — a per-weapon secondary stat with its own name (Stamina, Luck, Energy, etc.) and a maximum. Drives action costs.
+- **Action sets** — Defend, Attack (+ Attack Crit), and Special. You pick one Defend, Attack, or Special each turn; Attack Crit fires automatically.
+
+An **Action** has:
+- **Name** — the in-game name.
+- **Type** — one of the eight types ([Strike, Block, Buff, Debuff, Heal, DOT, Reflect, Shield](#combat-actions)).
+- **Damage Type** and **Damage Subtype** — see [Damage and Resistances](#damage-and-resistances).
+- **Field** or **Value** — the variable amount the action does. Field is rolled (e.g. damage per use); Value is fixed (e.g. block amount).
+- **Cost** — how much Resource it consumes. Negative cost restores Resource instead of spending it.
+- **Range** — how far it reaches in tiles.
+- **Aimed or Reactive** — targeting mode.
+- **Rounds** — for duration actions (DOT, Buff, Debuff, Reflect, Shield), how many rounds the effect lasts.
+
+For per-weapon stats and the exact actions of every weapon, see the [Weapon Stats](/app/weapon-stats) info page.
 
 ---
 
@@ -204,3 +229,11 @@ Quick reference. Click any term to jump to its section.
 **Professions**
 - [Lumberjack](#professions), [Blacksmith](#professions), [Enchanter](#professions).
 - [Hybrid weapon](#professions) — wood + talamite parts; both LJ and BS can upgrade.
+
+**Weapons**
+- [Weapon](#weapons) — your equipped loadout; provides HP, Resource, Actions.
+- [HP](#weapons), [Resource](#weapons), [Action sets](#weapons) — weapon properties.
+- [Action](#weapons) — one of the entries in a weapon's set. Has type, damage type/subtype, field/value, cost, range, aimed/reactive, rounds.
+- [Field vs Value](#weapons) — Field is a rolled range, Value is fixed.
+- [Cost](#weapons) — Resource consumed (negative = restored).
+- [Rounds](#weapons) — how long a duration action lasts.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -112,7 +112,7 @@ Hunts happen on the **Hunt** page. Each hunt costs one bait from the General Sto
 
 Each hunt rolls a fresh board layout with obstacles placed randomly in the open zone.
 
-**A bait occasionally pulls a second enemy of the same type** — about a 2.3% chance per hunt. Both must be defeated, each drops loot, and the combat log distinguishes them with an `A` / `B` suffix. Their action patterns start offset so they don't move in sync.
+**A bait occasionally pulls a second enemy of the same type** — a 2.3% chance per hunt. Both must be defeated, each drops loot, and the combat log distinguishes them with an `A` / `B` suffix. Their action patterns start offset so they don't move in sync.
 
 ---
 

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -195,7 +195,7 @@ Every item in your inventory has a type:
 
 **Higher-tier crafting**. Many weapons have alternate recipes that use higher-tier components and bake bonuses into the crafted weapon:
 
-- **Tier-2 recipes** — use tier-2 components (treated sulwood, talamite). The crafted weapon comes with **+1 attack** baked in. Only the two starting weapons currently have a tier-2 variant: **Quarterstaff (Treated)** at LJ level 2 and **Dagger (Talamite)** at BS level 2.
+- **Tier-2 recipes** — use tier-2 components (treated sulwood, talamite, hiruos). The crafted weapon comes with **+1 attack** baked in. The three starting weapons each have a tier-2 variant: **Quarterstaff (Treated)** at LJ level 2, **Dagger (Talamite)** at BS level 2, and **Spellbook (Hiruos)** at EN level 2.
 - **Tier-3 recipes** — use tier-3 components (hardwood, alloy, nodol). The crafted weapon comes with **+1 defend, +1 attack, +1 special** baked in. Every weapon has a tier-3 variant, unlocking at profession level 7.
 
 These baked-in bonuses don't count against your [upgrade budget](#the-bench) — they're part of the recipe. So crafting a hardwood quarterstaff gives you a +1/+1/+1 quarterstaff without spending any upgrade points.
@@ -269,5 +269,5 @@ Quick reference. Click any term to jump to its section.
 - [Component](#items) — crafted intermediate combined into a weapon (sword hilt, axe head, etc.). All components are also materials.
 - [Valuable](#items) — loot meant for selling.
 - [Consumable](#items) — single-use item (baits are the main example).
-- [Tier-2 recipe](#items) — alternate recipe for the L1 weapons (Quarterstaff, Dagger) using treated sulwood / talamite. Crafted weapon comes with +1 attack baked in.
+- [Tier-2 recipe](#items) — alternate recipe for the L1 weapons (Quarterstaff, Dagger, Spellbook) using treated sulwood / talamite / hiruos. Crafted weapon comes with +1 attack baked in.
 - [Tier-3 recipe](#items) — alternate recipe for every weapon using hardwood / alloy / nodol. Crafted weapon comes with +1 defend / +1 attack / +1 special baked in.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -23,13 +23,13 @@ Actions come in eight types. Some take effect immediately, others apply a durati
 | Type | Effect | Duration |
 |---|---|---|
 | **Strike** | Direct damage | Immediate |
-| **Block** | Reduces incoming damage this turn | Immediate |
-| **Buff** | Boosts the user's damage | Duration |
-| **Debuff** | Reduces the target's damage | Duration |
+| **Block** | Subtracts a flat amount from damage you take this round | Immediate |
+| **Buff** | Adds a flat amount to your damage rolls | Duration |
+| **Debuff** | Subtracts a flat amount from the target's damage rolls | Duration |
 | **Heal** | Restores HP | Immediate |
 | **DOT** (Damage Over Time) | Damage that ticks each round | Duration |
-| **Reflect** | Sends a portion of incoming damage back | Duration |
-| **Shield** | Soaks a fixed amount of damage | Duration |
+| **Reflect** | Sends a flat amount back any round you take a Strike | Duration |
+| **Shield** | Subtracts a flat amount from damage you take each round | Duration |
 
 **Field** is the roll table for any value that varies — usually the damage on a Strike or DOT tick. `Field: [0, 1, 2, 5, 6, 7, 8]` means each use picks one of those values at random. A wider range is swingier; a tighter range is more predictable.
 
@@ -42,7 +42,15 @@ Actions come in eight types. Some take effect immediately, others apply a durati
 
 **Attack Crit** fires when you use an Attack and your target uses a Special on the same turn. The crit lands **after** the main attack.
 
-**Damage modifier order.** When several effects are active on a turn, they apply to the raw damage roll in a fixed order: **Buffs** (boost the attacker) → **Debuffs** (reduce the attacker) → **Blocks** (subtract from incoming damage) → **Shields** (soak remaining damage). The combat log shows each step so you can see how the final number was reached.
+**How damage adds up.** When a Strike lands, the final damage is one arithmetic step:
+
+`damage = max(0, roll + attacker's Buff − attacker's Debuff − target's Block − target's Shield)`
+
+Final damage is never below zero. A few non-obvious rules:
+- **Buff and Debuff are mutually exclusive on the same target.** Applying one clears the other — you can't be both buffed and debuffed at once.
+- **Block lasts only the current round.** It resets to 0 at end of round, so you have to re-apply it each turn you want it.
+- **Shield reduces damage every round for its duration.** It's not a damage pool that depletes; the value stays the same each round until the duration ends.
+- **Reflect fires on any incoming Strike**, regardless of how much damage landed (even 0). It sends a flat amount back.
 
 ---
 

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -74,21 +74,48 @@ The combat log marks these with `[weakness — Hd4]` or `[resist — Ld2]` when 
 
 # The Battle
 
-Battles are turn-based on a small grid against an enemy from the [Enemies](/app/enemies) roster. Both combatants begin at **full HP and full Resource**.
+Battles are turn-based on a grid against one or more enemies from the [Enemies](/app/enemies) roster. Every combatant begins at **full HP and full Resource**.
 
 Each turn unfolds in three phases:
 
-1. **Intent phase** — you and the enemy each pick a move target and an action for the turn.
-2. **Move phase** — both sides execute their movement step.
+1. **Intent phase** — every combatant picks a move target and an action for the turn.
+2. **Move phase** — every combatant executes their movement step in [initiative](#initiative) order. If two combatants want the same tile, the higher-initiative one takes it; the other re-routes toward its original destination, or stays put if it can't get any closer.
 3. **Action phase** — actions resolve in a fixed order:
    - **Defend actions**
    - **Attack actions** (including Attack Crit triggers)
    - **Special actions**
    - **DOT ticks** (end of round)
 
-Within each action sub-phase, the player resolves before the AI — **except DOT ticks, where the AI ticks first**. The battle ends the moment any character reaches 0 HP — they are the loser. If both would drop from ticks on the same round, whichever reaches 0 first loses.
+Within each sub-phase, combatants act in [initiative](#initiative) order. The battle ends the moment any team has no combatants left with HP above 0 — that team loses.
 
 Range, line of sight, and **obstacles** all affect movement and targeting. Obstacles are rolled randomly per hunt and block both movement and aimed attacks. Diagonal moves cannot pass between two obstacles that touch corners.
+
+---
+
+# Initiative
+
+At the start of every battle, each combatant rolls `1..100 − Weight` to set their **initiative**. Higher initiative acts first in every sub-phase of every turn — defends, attacks, specials, DOT ticks, and movement priority.
+
+**Weight** is a per-weapon stat. Heavier weapons go later. The roll happens once at battle start and stays fixed for the rest of the fight.
+
+**Tiebreakers** (initiative ties are uncommon since the roll has 100 buckets):
+- A player wins ties against an NPC.
+- Otherwise, coin flip.
+
+The initiative log appears at the top of the combat log on every join, in the order combatants will act.
+
+---
+
+# Multi-enemy Combat
+
+Most hunts pull one enemy. Occasionally (about 2.3% of the time) a bait pulls a **second enemy** of the same type — you'll see two of them on the board, named `Lithkem Swallow A` and `Lithkem Swallow B` (for example) in the combat log.
+
+A few specifics:
+
+- Both enemies must reach 0 HP for you to win. Defeating one and dying to the other counts as a loss.
+- Each enemy rolls its own loot table on victory — two enemies, two loot rolls.
+- Each enemy starts at a random position in its action pattern, so identical enemies don't telegraph identical actions on turn 1.
+- Reactive attacks pick the nearest enemy in range; aimed attacks pick the target tile explicitly.
 
 ---
 
@@ -178,6 +205,7 @@ Your equipped **Weapon** sets your stats and dictates what actions are available
 A weapon has:
 - **HP** — the survival pool you fight with. Different weapons have different HP totals.
 - **Resource** — a per-weapon secondary stat with its own name (Stamina, Luck, Energy, etc.) and a maximum. Drives action costs.
+- **Weight** — drives the [initiative](#initiative) roll at battle start. Heavier weapons go later in the turn order.
 - **Action sets** — Defend, Attack (+ Attack Crit), and Special. You pick one Defend, Attack, or Special each turn; Attack Crit fires automatically.
 
 An **Action** has:
@@ -231,9 +259,12 @@ Quick reference. Click any term to jump to its section.
 **Combat**
 - [HP](#currency-and-stats) — survival pool. Reach 0 and you lose.
 - [Resource](#currency-and-stats) — per-weapon secondary stat (Stamina, Luck, etc.). Drives action costs.
+- [Weight](#weapons) — per-weapon stat. Drives initiative; heavier = later.
+- [Initiative](#initiative) — `1..100 − Weight` rolled at battle start. Sets turn order for the whole fight.
 - [Action](#weapons) — one entry in a weapon's set. Has a type, damage type/subtype, field/value, cost, range, aimed/reactive, and (for duration) rounds.
 - [Action sets](#weapons) — every weapon has Defend, Attack (+ Attack Crit), and Special sets.
 - [Obstacle](#the-battle) — board feature blocking movement and aimed attacks.
+- [Multi-enemy](#multi-enemy-combat) — about 2.3% of hunts pull a second enemy of the same type. Both must be defeated to win; each rolls its own loot.
 
 **Action types** (what an Action does)
 - [Strike](#combat-actions) — direct damage.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -193,13 +193,14 @@ Every item in your inventory has a type:
 - **Valuable** — loot from enemies meant for selling (swallow feather, venison, melstone, lifgem, etc.). Generally not used in crafting.
 - **Consumable** — spent on use. Baits are the main consumables — one is consumed per hunt.
 
-**Components have tiers**. Most weapons have a base recipe plus one or two higher-tier variants:
+**Higher-tier crafting**. Many weapons have alternate recipes that use higher-tier components and bake bonuses into the crafted weapon:
 
-- **Tier-1** — the base recipe. Uses raw or unprocessed material. No bundled bonus.
-- **Tier-2** — uses tier-2 components (treated sulwood, talamite, hiruos). The crafted weapon comes with a free **+1 attack** baked in. Unlocks at profession level 2–3.
-- **Tier-3** — uses tier-3 components (hardwood, alloy, nodol). The crafted weapon comes with **+1 defend, +1 attack, +1 special** baked in. Unlocks at profession level 7.
+- **Tier-2 recipes** — use tier-2 components (treated sulwood, talamite). The crafted weapon comes with **+1 attack** baked in. Only the two starting weapons currently have a tier-2 variant: **Quarterstaff (Treated)** at LJ level 2 and **Dagger (Talamite)** at BS level 2.
+- **Tier-3 recipes** — use tier-3 components (hardwood, alloy, nodol). The crafted weapon comes with **+1 defend, +1 attack, +1 special** baked in. Every weapon has a tier-3 variant, unlocking at profession level 7.
 
-These free bonuses don't count against your [upgrade budget](#the-bench) — they're part of the recipe. So crafting a hardwood quarterstaff gives you a quarterstaff that's already +1/+1/+1 without spending any upgrade points.
+These baked-in bonuses don't count against your [upgrade budget](#the-bench) — they're part of the recipe. So crafting a hardwood quarterstaff gives you a +1/+1/+1 quarterstaff without spending any upgrade points.
+
+See the [Professions](/app/professions) info page for the full list of which recipes are available at each level.
 
 ---
 
@@ -268,4 +269,5 @@ Quick reference. Click any term to jump to its section.
 - [Component](#items) — crafted intermediate combined into a weapon (sword hilt, axe head, etc.). All components are also materials.
 - [Valuable](#items) — loot meant for selling.
 - [Consumable](#items) — single-use item (baits are the main example).
-- [Tier-1 / Tier-2 / Tier-3](#items) — component tiers. Tier-2 weapons get +attack baked in; tier-3 get +defend/+attack/+special.
+- [Tier-2 recipe](#items) — alternate recipe for the L1 weapons (Quarterstaff, Dagger) using treated sulwood / talamite. Crafted weapon comes with +1 attack baked in.
+- [Tier-3 recipe](#items) — alternate recipe for every weapon using hardwood / alloy / nodol. Crafted weapon comes with +1 defend / +1 attack / +1 special baked in.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -1,84 +1,85 @@
 # Currency and Stats
 
-**Korel** is the standard currency. Stamped with Emperor Gustavus's face. Earned by selling loot to shops and from battle rewards. Used to buy weapons, baits, materials, and upgrades.
+**Korel** is the standard currency. Earned by selling loot to shops and from battle rewards. Used to buy weapons, baits, materials, and upgrades.
 
 **Health (HP)** is your survival pool in a fight. Drops to zero, you lose the battle.
 
-**Resource** is a per-weapon secondary stat. Each weapon has its own — Stamina for an axe, Tar for a Golnosar — and most attacks cost some to use. Defensive actions usually restore it. Different weapons play very differently because of their resource rhythm.
+**Resource** is a per-weapon secondary stat. Each weapon has its own — Stamina for an axe, Energy for a deck of cards — and most attacks cost some to use. Most weapons have a dedicated action to restore it. Different weapons play very differently because of their resource rhythm.
 
 ---
 
 # Combat Actions
 
-Every weapon has six action sets:
+Every weapon has three action sets, plus an attack crit:
 
-- **Defend** and **Defend Crit**
+- **Defend**
 - **Attack** and **Attack Crit**
-- **Special** and **Special Crit**
+- **Special**
 
-You pick one Defend, Attack, or Special each turn. The "Crit" variants are bonus actions that fire automatically when conditions are met (see Crits below).
+You pick one Defend, Attack, or Special each turn. The Attack Crit is a bonus action that fires automatically when the conditions are met (see Crits below).
 
-Actions come in eight types:
+Actions come in eight types. Some take effect immediately, others apply a duration over several rounds. **Duration effects never stack** — applying a new one replaces the existing one on the same target.
 
-- **Strike** — direct damage
-- **Block** — reduces incoming damage this turn
-- **Buff** — adds an effect that helps the user (e.g., boosts damage)
-- **Debuff** — adds an effect that hurts the target (e.g., reduces their damage)
-- **Heal** — restores HP
-- **DOT (Damage Over Time)** — ticks damage for several rounds after it lands
-- **Reflect** — sends a portion of incoming damage back at the attacker
-- **Shield** — soaks a fixed amount of damage over multiple turns
+| Type | Effect | Duration |
+|---|---|---|
+| **Strike** | Direct damage | Immediate |
+| **Block** | Reduces incoming damage this turn | Immediate (this turn only) |
+| **Buff** | Boosts the user's damage | Duration |
+| **Debuff** | Reduces the target's damage | Duration |
+| **Heal** | Restores HP | Immediate |
+| **DOT** (Damage Over Time) | Damage that ticks each round | Duration |
+| **Reflect** | Sends a portion of incoming damage back | Duration |
+| **Shield** | Soaks a fixed amount of damage | Duration |
 
-**DOTs do not stack.** A new DOT replaces the existing one on the same target.
+**Field** is the roll table for any value that varies — damage on a Strike, damage per tick on a DOT, even shield/block values. `Field: [0, 1, 2, 5, 6, 7, 8]` means each use picks one of those values at random. A wider range is swingier; a tighter range is more predictable.
 
-**Field** is the damage roll table for an attack. `Field: [0, 1, 2, 5, 6, 7, 8]` means each hit picks one of those values at random. A wider range means swingier; a tighter range means predictable.
-
-**Range** is how far the action can reach measured in tiles (diagonals count as one step).
+**Range** is how far the action can reach, measured in tiles (diagonals count as one step).
 
 **Aimed vs Reactive**:
-- **Aimed** — you pick a target tile before the attack fires. Lets you hit specific positions or save a powerful attack for a moment when the enemy is in range.
-- **Reactive** — fires automatically at the nearest valid target in range. Less control, more reliable.
+- **Aimed** — you pick a target tile before the attack fires. Less reliable, because the target can move off the tile.
+- **Reactive** — fires automatically at the nearest valid target in range. More reliable.
 
-**Crits (`attack_crit`)** fire when you use an Attack and your target uses a Special on the same turn. The crit lands *before* the main attack. Defend Crit and Special Crit work analogously for those action types.
+**Crits** — `attack_crit` fires when you use an Attack and your target uses a Special on the same turn. The crit lands **after** the main attack.
 
 ---
 
 # Damage and Resistances
 
-Every action carries a **Damage Type** and a **Damage Subtype**.
+Every action carries a **Damage Type** and a **Damage Subtype**. Any type/subtype combination is possible (an action can be Arcane Sharp or Elemental Blunt — enchants make these mixes).
 
-**Damage Types**
-- **Physical** — Sharp, Blunt, Poison
+**Damage Types** and their typical subtypes:
+- **Physical** — Sharp, Blunt
 - **Arcane** — Mental, Force
 - **Elemental** — Fire, Water, Earth, Wind, Plant
 
-Enemies have **Resistances** as multiplier scores against each type and subtype. Your action's type score and subtype score multiply together. The combined number doesn't directly multiply damage — it changes the *shape* of the roll:
+Enemies have **Resistances** against each type and subtype. Your action's type and subtype are evaluated against the enemy's, and the result maps to a roll mode:
 
-- Combined > 1.0 — **weakness** — roll 4 dice, take the highest (Hd4). Big variance, skews high.
-- Combined < 1.0 — **resist** — roll 2 dice, take the lowest (Ld2). Skews low.
-- Combined = 1.0 — **neutral** — single roll. Baseline.
+| Matchup | Roll mode | Behavior |
+|---|---|---|
+| **Weakness** | **Hd4** | Roll 4 dice, take the highest. Big variance, skews high. |
+| **Resist** | **Ld2** | Roll 2 dice, take the lowest. Skews low. |
+| **Neutral** | **1d** | Single roll. Baseline. |
 
-The combat log marks these with `[weakness — Hd4]` or `[resist — Ld2]` when active. Matching damage types to enemy weaknesses isn't always a guaranteed bonus, but it dramatically shifts the odds in your favor.
+The combat log marks these with `[weakness — Hd4]` or `[resist — Ld2]` when active. Matching damage types to enemy weaknesses isn't a guaranteed bonus, but it dramatically shifts the odds in your favor.
 
 ---
 
 # The Battle
 
-Battles are turn-based on a small grid. Each turn unfolds in three phases:
+Battles are turn-based on a small grid. You and your enemy submit your choices each turn, then resolution runs in two phases:
 
-1. **Intent** — you and the enemy each choose an action.
-2. **Move** — both sides take their movement step.
-3. **Action** — Defends resolve first, then Attacks, then Specials. Within each sub-phase, the player resolves before the AI.
+1. **Move phase** — both sides execute their movement step.
+2. **Action phase** — Defends resolve first, then Attacks, then Specials. Within each sub-phase, the player resolves before the AI.
 
-You and your enemy share the board. Position matters: range, line of sight, and which tiles get blocked by obstacles all shape what's possible. The board includes **obstacles** — rolled randomly per hunt — that block both movement and aimed attacks. Diagonal moves can't slip between two obstacles that touch corners.
+Position matters: range, line of sight, and which tiles get blocked by **obstacles** all shape what's possible. Obstacles are rolled randomly per hunt and block both movement and aimed attacks. Diagonal moves can't slip between two obstacles that touch corners.
 
-DOTs tick at end of round. If a fight ends with both combatants dying to DOT damage on the same tick, the AI's DOT resolves first, then yours — death is checked between.
+**The battle ends the moment any character reaches 0 HP — they're the loser.** DOTs tick at end of round and are checked the same way: whoever drops first is the loser.
 
 ---
 
 # Hunting
 
-Hunts happen on the **Hunt** page. Each hunt costs one **bait** from the General Store, and each bait summons one specific enemy:
+Hunts happen on the **Hunt** page. Each hunt costs one bait from the General Store, and each bait summons one specific enemy:
 
 | Bait | Enemy |
 |---|---|
@@ -90,9 +91,9 @@ Hunts happen on the **Hunt** page. Each hunt costs one **bait** from the General
 | Tar Bait | Golnosar |
 | Bear Bait | Melbear |
 
-**Loot** is rolled at the end of a victorious battle, not per turn. Each enemy has a drop table — see the **Enemies** info page for the exact roll tables.
+**Loot** is rolled at the end of a victorious battle, not per turn. Each enemy has a drop table — see the [Enemies](/app/enemies) info page for exact roll tables.
 
-Each hunt rolls a fresh board layout: 2–6 obstacles placed randomly in the open zone. The tutorial board is fixed.
+Each hunt rolls a fresh board layout: 2–6 obstacles placed randomly in the open zone.
 
 ---
 
@@ -105,7 +106,7 @@ Sulku'it has four shops. Each one buys back items at a sell price and stocks goo
 - **Lumberjack** (Vetha) — sulwood materials, wood weapons, lumber components.
 - **Enchanting Shop** (Lomis) — enchanting reagents, arcane weapons, valuable gemstones.
 
-**Prices move with the market.** Shops respond to player trading: heavy buying pushes prices up, heavy selling pushes them down. Some items (valuables) swing harder; bulk materials shift more slowly. Idle items drift back toward their baseline.
+Prices move with the market. Shops respond to player trading: heavy buying pushes prices up, heavy selling pushes them down. Some items (valuables) swing harder; bulk materials shift more slowly. Idle items drift back toward their baseline.
 
 If a shop's shelf is full of an item, it stops buying that item until stock clears. Shops dump excess stock on their own schedule to keep things flowing.
 
@@ -115,56 +116,34 @@ If a shop's shelf is full of an item, it stops buying that item until stock clea
 
 The **Bench** is where you turn materials into things. It splits into three pages, one per profession:
 
-- **Crafting** — combine materials and components into finished weapons, intermediates, and enchanting reagents. The recipe is fixed; you provide the inputs.
+- **Crafting** — combine materials and components into finished weapons, intermediates, and enchanting reagents.
 - **Upgrading** — spend tier-2 or tier-3 material on a weapon you own to permanently boost its stats. Each profession has its own upgrade budget per weapon.
-- **Enchanting** — apply an enchant to one of a weapon's three enchant slots. Enchants change an action's damage subtype (minor) or its full damage type and subtype (major). Three enchant slots per weapon, one enchant per action, permanent.
+- **Enchanting** — apply an enchant to one of a weapon's three enchant slots. A **minor** enchant changes the **Damage Subtype** of one action; a **major** enchant changes both **Damage Type** and **Damage Subtype** (and adds a small bonus). Three enchant slots per weapon, one enchant per action, permanent.
 
 ---
 
 # Professions
 
-There are three professions: **Lumberjack (LJ)**, **Blacksmith (BS)**, and **Enchanter**. You can level each one from 1 to 10. Total combined level is capped at 30, so leveling all three to max is possible but takes work.
+There are three professions: **Lumberjack (LJ)**, **Blacksmith (BS)**, and **Enchanter**. You can level each one from 1 to 10. Total combined level is capped at 30 — that's enough to max two and leave one at 10, or spread your levels more evenly. The cap means specializing is encouraged: you can't be the master of everything, and other players are expected to fill the gaps via trade.
 
 | Profession | What it crafts | What it upgrades |
 |---|---|---|
-| Lumberjack | Wood and hybrid weapons | Any weapon with a wood component |
-| Blacksmith | Metal weapons | Talamite-only weapons (no wood handle) |
-| Enchanter | Enchanting reagents and arcane weapons | All weapons (via enchants) |
+| Lumberjack | Wood and hybrid weapons | Any weapon containing a wood component |
+| Blacksmith | Metal weapons | Any weapon containing talamite |
+| Enchanter | Enchanter-tree weapons (spellbook, wand, kustaff, deck of cards, mental cage) | Enchanter-tree weapons |
 
-Hybrid weapons (Sword (Talamite), Axe (Talamite), Shovel (Talamite)) can be upgraded by **either** LJ or BS — cross-profession collaboration is intentional.
+Hybrid weapons (Sword (Talamite), Axe (Talamite), Shovel (Talamite)) have both wood and talamite parts, so **both** LJ and BS can upgrade them — cross-profession collaboration is intentional.
 
-Each profession level grants either a new recipe or a bigger upgrade budget. See the **Professions** info page for the full per-level breakdown.
+Enchanting is a separate system from upgrades. Any profession's weapon can receive enchants (apply via the Enchanting page above).
+
+Each profession level grants either a new recipe or a bigger upgrade budget. See the [Professions](/app/professions) info page for the full per-level breakdown.
 
 ---
 
 # Trading
 
-You can trade with another player at any time. From the **Trade** page, search a partner by character name, and you'll both land in a shared trade view.
+You can trade with another player at any time. From the **Trade** page, search a partner by character name and you'll both land in a shared trade view.
 
-Both sides drop items, weapons, and **korel** into their offer panel. Each side must **lock in** their offer (no further changes), then both must **confirm**. The transfer happens atomically — if anything goes wrong, nobody loses anything.
+Both sides drop items, weapons, and korel into their offer panel. Each side must lock in their offer (no further changes), then both must confirm. The transfer happens atomically — if anything goes wrong, nobody loses anything.
 
-Equipped weapons can't be traded. Unequip first if you want to send one across.
-
----
-
-# The Pages
-
-The sidebar groups everything you'll touch into four areas.
-
-**Top group** (your character and the world):
-- **Character** — your sprite, stats, profession levels.
-- **Inventory** — your items and weapons. Equip weapons from here.
-- **Hunt** — pick a bait, start a battle.
-- **Trade** — open a trade session with another player.
-
-**Bench** (production):
-- **Crafting**, **Upgrading**, **Enchanting** — described above.
-
-**Town** (the four shops): General Store, Blacksmith, Lumberjack, Enchanting Shop.
-
-**Info** (reference, no game state changes):
-- **Professions** — per-level recipe and budget breakdown.
-- **Enemies** — drop tables for every enemy.
-- **Weapon Stats** — action stats and damage fields for every weapon.
-- **Lore** — the world, its peoples, the town.
-- **Reference** — this page.
+Equipped weapons can't be traded.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -76,46 +76,21 @@ The combat log marks these with `[weakness — Hd4]` or `[resist — Ld2]` when 
 
 Battles are turn-based on a grid against one or more enemies from the [Enemies](/app/enemies) roster. Every combatant begins at **full HP and full Resource**.
 
+At the start of every battle, every combatant rolls for **initiative** — a random score that decides turn order for the whole fight. Lighter weapons (lower **Weight**) roll higher on average and act earlier. The rolls appear at the top of the combat log in the order combatants will act. On a rare tied roll, the player wins against an NPC; otherwise it's a coin flip.
+
 Each turn unfolds in three phases:
 
 1. **Intent phase** — every combatant picks a move target and an action for the turn.
-2. **Move phase** — every combatant executes their movement step in [initiative](#initiative) order. If two combatants want the same tile, the higher-initiative one takes it; the other re-routes toward its original destination, or stays put if it can't get any closer.
+2. **Move phase** — every combatant executes their movement step in initiative order. If two combatants want the same tile, the higher-initiative one takes it; the other re-routes toward its original destination, or stays put if it can't get any closer.
 3. **Action phase** — actions resolve in a fixed order:
    - **Defend actions**
    - **Attack actions** (including Attack Crit triggers)
    - **Special actions**
    - **DOT ticks** (end of round)
 
-Within each sub-phase, combatants act in [initiative](#initiative) order. The battle ends the moment any team has no combatants left with HP above 0 — that team loses.
+Within each sub-phase, combatants act in initiative order. The battle ends the moment any team has no combatants left with HP above 0 — that team loses.
 
 Range, line of sight, and **obstacles** all affect movement and targeting. Obstacles are rolled randomly per hunt and block both movement and aimed attacks. Diagonal moves cannot pass between two obstacles that touch corners.
-
----
-
-# Initiative
-
-At the start of every battle, each combatant rolls `1..100 − Weight` to set their **initiative**. Higher initiative acts first in every sub-phase of every turn — defends, attacks, specials, DOT ticks, and movement priority.
-
-**Weight** is a per-weapon stat. Heavier weapons go later. The roll happens once at battle start and stays fixed for the rest of the fight.
-
-**Tiebreakers** (initiative ties are uncommon since the roll has 100 buckets):
-- A player wins ties against an NPC.
-- Otherwise, coin flip.
-
-The initiative log appears at the top of the combat log on every join, in the order combatants will act.
-
----
-
-# Multi-enemy Combat
-
-Most hunts pull one enemy. Occasionally (about 2.3% of the time) a bait pulls a **second enemy** of the same type — you'll see two of them on the board, named `Lithkem Swallow A` and `Lithkem Swallow B` (for example) in the combat log.
-
-A few specifics:
-
-- Both enemies must reach 0 HP for you to win. Defeating one and dying to the other counts as a loss.
-- Each enemy rolls its own loot table on victory — two enemies, two loot rolls.
-- Each enemy starts at a random position in its action pattern, so identical enemies don't telegraph identical actions on turn 1.
-- Reactive attacks pick the nearest enemy in range; aimed attacks pick the target tile explicitly.
 
 ---
 
@@ -135,7 +110,9 @@ Hunts happen on the **Hunt** page. Each hunt costs one bait from the General Sto
 
 **Loot** is rolled at the end of a victorious battle. Each enemy has a drop table — see the [Enemies](/app/enemies) info page for exact roll tables.
 
-Each hunt rolls a fresh board layout: 2–6 obstacles placed randomly in the open zone.
+Each hunt rolls a fresh board layout with obstacles placed randomly in the open zone.
+
+**Occasionally a bait pulls a second enemy** of the same type — roughly one hunt in forty. Two enemies share the board and the combat log distinguishes them with an `A` / `B` suffix (e.g. `Lithkem Swallow A`, `Lithkem Swallow B`). Both must be defeated to win; each rolls its own loot table independently. Each enemy starts at a random position in its action pattern, so identical enemies don't telegraph identical actions on turn 1.
 
 ---
 
@@ -259,12 +236,11 @@ Quick reference. Click any term to jump to its section.
 **Combat**
 - [HP](#currency-and-stats) — survival pool. Reach 0 and you lose.
 - [Resource](#currency-and-stats) — per-weapon secondary stat (Stamina, Luck, etc.). Drives action costs.
-- [Weight](#weapons) — per-weapon stat. Drives initiative; heavier = later.
-- [Initiative](#initiative) — `1..100 − Weight` rolled at battle start. Sets turn order for the whole fight.
+- [Weight](#weapons) — per-weapon stat. Heavier weapons act later in the turn order.
+- [Initiative](#the-battle) — random score rolled at battle start that decides turn order. Lower Weight tends to mean higher initiative.
 - [Action](#weapons) — one entry in a weapon's set. Has a type, damage type/subtype, field/value, cost, range, aimed/reactive, and (for duration) rounds.
 - [Action sets](#weapons) — every weapon has Defend, Attack (+ Attack Crit), and Special sets.
 - [Obstacle](#the-battle) — board feature blocking movement and aimed attacks.
-- [Multi-enemy](#multi-enemy-combat) — about 2.3% of hunts pull a second enemy of the same type. Both must be defeated to win; each rolls its own loot.
 
 **Action types** (what an Action does)
 - [Strike](#combat-actions) — direct damage.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -131,7 +131,9 @@ The **Bench** is where you turn materials into things. It splits into three page
 
 There are three professions: **Lumberjack (LJ)**, **Blacksmith (BS)**, and **Enchanter**. You can level each one from 1 to 10, with a combined cap of 30 across all three.
 
-The cost to gain a level depends only on that profession's current level — leveling 1 → 2 is cheap, leveling 9 → 10 is expensive — independent of your other profession levels. That means spreading levels evenly is cheaper per level, but specializing reaches high-tier recipes and bigger upgrade budgets sooner. Other players are expected to fill the gaps via trade.
+The cost of a level depends on your **total** profession levels across all three. Your 1st level (in any profession) is cheap; your 30th — the last one to reach the cap — is expensive. The profession you put it into doesn't change the price.
+
+That means picking up a second or third profession late is costly, and specializing is the cheaper path. Other players are expected to fill the gaps via trade.
 
 You raise profession levels on your [Character](/app/character) page.
 
@@ -186,26 +188,41 @@ For per-weapon stats and the exact actions of every weapon, see the [Weapon Stat
 
 Quick reference. Click any term to jump to its section.
 
-**Currency and stats**
+**Big concepts**
 - [Korel](#currency-and-stats) — the standard currency.
-- [HP](#currency-and-stats) — health pool; drops to 0, you lose.
-- [Resource](#currency-and-stats) — per-weapon secondary stat (Stamina, Luck, Tar, etc.).
+- [Weapon](#weapons) — your equipped loadout; determines stats and available actions.
+- [Profession](#professions) — Lumberjack, Blacksmith, or Enchanter. Combined cap of 30 levels.
+- [Bench](#the-bench) — your production area, split into Crafting / Upgrading / Enchanting.
+- [Bait](#hunting) — consumable that summons one specific enemy.
+- [Loot](#hunting) — drops rolled at end of a victorious battle.
 
-**Combat actions**
+**Combat objects**
+- [HP](#currency-and-stats) — survival pool. Reach 0 and you lose.
+- [Resource](#currency-and-stats) — per-weapon secondary stat (Stamina, Luck, etc.). Drives action costs.
+- [Action](#weapons) — one entry in a weapon's set. Has a type, damage type/subtype, field/value, cost, range, aimed/reactive, and (for duration) rounds.
+- [Action sets](#weapons) — every weapon has Defend, Attack (+ Attack Crit), and Special sets.
+- [Obstacle](#the-battle) — board feature blocking movement and aimed attacks.
+
+**Action types** (what an Action does)
 - [Strike](#combat-actions) — direct damage.
 - [Block](#combat-actions) — reduces this turn's incoming damage.
 - [Buff](#combat-actions) — boosts user's damage for a duration.
 - [Debuff](#combat-actions) — reduces target's damage for a duration.
 - [Heal](#combat-actions) — restores HP.
 - [DOT](#combat-actions) — Damage Over Time; ticks each round.
-- [Reflect](#combat-actions) — returns a portion of incoming damage.
+- [Reflect](#combat-actions) — returns a portion of incoming damage for a duration.
 - [Shield](#combat-actions) — soaks a fixed amount of damage over multiple turns.
-- [Field](#combat-actions) — the roll table for a variable value.
-- [Range](#combat-actions) — reach in tiles (diagonal counts as one).
-- [Aimed](#combat-actions) — pick a tile to fire at.
-- [Reactive](#combat-actions) — fires at nearest valid target automatically.
-- [Attack Crit](#combat-actions) — bonus action when your Attack meets enemy Special.
-- [Duration](#combat-actions) — multi-round effects; never stack.
+
+**Action properties** (numbers attached to an Action)
+- [Field](#weapons) — roll table for a variable value (rolls one entry per use).
+- [Value](#weapons) — fixed amount (e.g. block value, shield value).
+- [Range](#weapons) — reach in tiles (diagonal counts as one).
+- [Cost](#weapons) — Resource consumed (negative cost restores instead).
+- [Rounds](#weapons) — how long a duration action lasts.
+- [Aimed](#combat-actions) — you pick a target tile. Less reliable.
+- [Reactive](#combat-actions) — auto-fires at nearest valid target. More reliable.
+- [Attack Crit](#combat-actions) — bonus action when your Attack meets enemy Special. Resolves after the main attack.
+- [Duration](#combat-actions) — multi-round effects; never stack — a new application replaces the existing one.
 
 **Damage**
 - [Damage Type](#damage-and-resistances) — Physical / Arcane / Elemental.
@@ -214,28 +231,15 @@ Quick reference. Click any term to jump to its section.
 - [Resist](#damage-and-resistances) — Ld2 roll (skews low).
 - [Neutral](#damage-and-resistances) — 1d roll (baseline).
 
-**Battle**
+**Turn flow**
 - [Intent phase](#the-battle) — choose your move + action.
-- [Move phase](#the-battle) — both sides step.
-- [Action phase](#the-battle) — Defends → Attacks → Specials → DOT ticks.
-- [Obstacle](#the-battle) — blocks movement and aimed attacks.
+- [Move phase](#the-battle) — both sides execute their movement step.
+- [Action phase](#the-battle) — Defend → Attack → Special → DOT ticks. Player resolves before AI except DOTs (AI first).
 
-**Hunt and economy**
-- [Bait](#hunting) — consumable that summons one enemy.
-- [Loot](#hunting) — drops rolled on victory.
-- [Bench](#the-bench) — your production area.
-- [Crafting](#the-bench), [Upgrading](#the-bench), [Enchanting](#the-bench) — Bench activities.
-- [Minor enchant](#the-bench) — changes subtype, small bonus.
-- [Major enchant](#the-bench) — changes type + subtype, +3 bonus.
-
-**Professions**
-- [Lumberjack](#professions), [Blacksmith](#professions), [Enchanter](#professions).
-- [Hybrid weapon](#professions) — wood + talamite parts; both LJ and BS can upgrade.
-
-**Weapons**
-- [Weapon](#weapons) — your equipped loadout; provides HP, Resource, Actions.
-- [HP](#weapons), [Resource](#weapons), [Action sets](#weapons) — weapon properties.
-- [Action](#weapons) — one of the entries in a weapon's set. Has type, damage type/subtype, field/value, cost, range, aimed/reactive, rounds.
-- [Field vs Value](#weapons) — Field is a rolled range, Value is fixed.
-- [Cost](#weapons) — Resource consumed (negative = restored).
-- [Rounds](#weapons) — how long a duration action lasts.
+**Production**
+- [Crafting](#the-bench) — turn materials into weapons, intermediates, reagents.
+- [Upgrading](#the-bench) — permanently boost a weapon's stats.
+- [Enchanting](#the-bench) — apply an enchant to one of a weapon's three slots.
+- [Minor enchant](#the-bench) — changes Damage Subtype, small bonus.
+- [Major enchant](#the-bench) — changes Damage Type and Subtype, +3 bonus.
+- [Hybrid weapon](#professions) — has wood and talamite parts; both LJ and BS can upgrade.

--- a/database/docs/reference.md
+++ b/database/docs/reference.md
@@ -1,6 +1,6 @@
 # Currency and Stats
 
-**Korel** is the standard currency. Earned by selling loot to shops and from battle rewards. Used to buy weapons, baits, materials, and upgrades.
+**Korel** is the standard currency. Earned by selling loot to shops and from battle rewards. Used to buy weapons, baits, and materials.
 
 **Health (HP)** is your survival pool in a fight. Drops to zero, you lose the battle.
 
@@ -71,9 +71,9 @@ Battles are turn-based on a small grid against an enemy from the [Enemies](/app/
 1. **Intent phase** — you and the enemy each pick a move target and an action for the turn.
 2. **Move phase** — both sides execute their movement step.
 3. **Action phase** — actions resolve in a fixed order:
-   - **Defends**
-   - **Attacks** (including Attack Crit triggers)
-   - **Specials**
+   - **Defend actions**
+   - **Attack actions** (including Attack Crit triggers)
+   - **Special actions**
    - **DOT ticks** (end of round)
 
 **Within each action sub-phase, the player resolves before the AI — except DOT ticks, where the AI ticks first.** The battle ends the moment any character reaches 0 HP — they're the loser, even if a tick on the same round would have killed both.
@@ -96,7 +96,7 @@ Hunts happen on the **Hunt** page. Each hunt costs one bait from the General Sto
 | Tar Bait | Golnosar |
 | Bear Bait | Melbear |
 
-**Loot** is rolled at the end of a victorious battle, not per turn. Each enemy has a drop table — see the [Enemies](/app/enemies) info page for exact roll tables.
+**Loot** is rolled at the end of a victorious battle. Each enemy has a drop table — see the [Enemies](/app/enemies) info page for exact roll tables.
 
 Each hunt rolls a fresh board layout: 2–6 obstacles placed randomly in the open zone.
 
@@ -129,7 +129,9 @@ The **Bench** is where you turn materials into things. It splits into three page
 
 # Professions
 
-There are three professions: **Lumberjack (LJ)**, **Blacksmith (BS)**, and **Enchanter**. You can level each one from 1 to 10. Total combined level is capped at 30 — that's enough to max two and leave one at 10, or spread your levels more evenly. The cap means specializing is encouraged: you can't be the master of everything, and other players are expected to fill the gaps via trade.
+There are three professions: **Lumberjack (LJ)**, **Blacksmith (BS)**, and **Enchanter**. You can level each one from 1 to 10, with a combined cap of 30 across all three.
+
+The cost to gain a level depends only on that profession's current level — leveling 1 → 2 is cheap, leveling 9 → 10 is expensive — independent of your other profession levels. That means spreading levels evenly is cheaper per level, but specializing reaches high-tier recipes and bigger upgrade budgets sooner. Other players are expected to fill the gaps via trade.
 
 You raise profession levels on your [Character](/app/character) page.
 
@@ -159,7 +161,7 @@ Equipped weapons can't be traded.
 
 # Weapons
 
-A **Weapon** is the centerpiece of your loadout. The weapon you have equipped determines your stats and what actions you can take in a battle.
+Your equipped **Weapon** sets your stats and dictates what actions are available in a fight. Different weapons play very differently — different HP totals, different resource rhythms, different action mixes.
 
 A weapon has:
 - **HP** — the survival pool you fight with. Different weapons have different HP totals.

--- a/database/enemies/daefen_deer.yaml
+++ b/database/enemies/daefen_deer.yaml
@@ -32,6 +32,7 @@ Image: ""
 Weapon:
   Name: Burning Antlers
   Description: A daefen deer, antlers ablaze with elemental charge.
+  Weight: 0
   Resource:
     Name: Rein
     Max: 10

--- a/database/enemies/golnosar.yaml
+++ b/database/enemies/golnosar.yaml
@@ -35,6 +35,7 @@ Image: ""
 Weapon:
   Name: Living Tar
   Description: A golnosar, dripping with the black resin that fuels it.
+  Weight: 0
   Resource:
     Name: Tar
     Max: 10

--- a/database/enemies/lithkem_swallow.yaml
+++ b/database/enemies/lithkem_swallow.yaml
@@ -29,6 +29,7 @@ Image: ""
 Weapon:
   Name: Beak and Wings
   Description: A lithkem swallow in a fighting stance.
+  Weight: 0
   Resource:
     Name: Water
     Max: 7

--- a/database/enemies/maetoad.yaml
+++ b/database/enemies/maetoad.yaml
@@ -21,6 +21,7 @@ Image: ""
 Weapon:
   Name: Maek Glands
   Description: A maetoad, Maek pooling behind its eyes.
+  Weight: 0
   Resource:
     Name: Maek
     Max: 8

--- a/database/enemies/melbear.yaml
+++ b/database/enemies/melbear.yaml
@@ -34,6 +34,7 @@ Image: ""
 Weapon:
   Name: Melbear Claws
   Description: A melbear, heavy with solitude and bristling with claws.
+  Weight: 0
   Resource:
     Name: Solitude
     Max: 8

--- a/database/enemies/sulfolk.yaml
+++ b/database/enemies/sulfolk.yaml
@@ -29,6 +29,7 @@ Image: ""
 Weapon:
   Name: Regrown Claws
   Description: A sulfolk, limbs rebuilt and ready.
+  Weight: 0
   Resource:
     Name: Nutrients
     Max: 10

--- a/database/enemies/talwyrm.yaml
+++ b/database/enemies/talwyrm.yaml
@@ -19,6 +19,7 @@ Image: ""
 Weapon:
   Name: Crystal Fangs
   Description: A talwyrm, scales hardened with crude talamite crystal.
+  Weight: 0
   Resource:
     Name: Talam
     Max: 4

--- a/database/enemies/tutorial_swallow.yaml
+++ b/database/enemies/tutorial_swallow.yaml
@@ -27,6 +27,7 @@ Image: ""
 Weapon:
   Name: Beak and Wings
   Description: A lithkem swallow in a fighting stance.
+  Weight: 0
   Resource:
     Name: Water
     Max: 7

--- a/database/lore/world_player.md
+++ b/database/lore/world_player.md
@@ -10,9 +10,9 @@ The town has become an outpost for those looking to make a name for themselves. 
 
 # The Chaevul Empire
 
-The empire is ruled by **Emperor Gustavus**. His face is stamped on every korel coin — the most common way most subjects encounter him in their daily lives. He also appears as the king card in standard playing decks across the continent.
+The empire is ruled by **Emperor Gustavus**. His face is stamped on every korel coin — the most common way most subjects encounter him in their daily lives.
 
-The empire's two peoples coexist uneasily in the conquered territories. The **Chae** are the empire's dominant culture: orderly, methodical, given to study and the systematizing of the world. The **Ketulvu** are the people who lived in these lands before the conquest. Their traditions predate the empire by centuries and have not been erased — only forced to share space with it.
+The empire spans many peoples. Two of them meet in Sulku'it: the **Chae**, the empire's dominant culture — orderly, methodical, given to study and the systematizing of the world — and the **Ketulvu**, the people who lived in these lands before the conquest. Ketulvu traditions predate the empire by centuries and have not been erased, only forced to share space with it.
 
 ---
 
@@ -30,7 +30,7 @@ Both traditions produce practitioners. The tension between them is cultural and 
 
 # The Gods
 
-The Ketulvu pantheon is older than the empire and quietly resilient. Three names recur most often:
+The Ketulvu pantheon is wide and older than the empire. A few names a newcomer to Sulku'it is likely to hear:
 
 - **Dae** — the source of Sidaev. Honored in every act of crafting, enchanting, and healing that draws on the living force.
 - **Vidali** — the god of life. Patroness of growth, healing, and what endures.
@@ -52,31 +52,31 @@ The town square is the gathering point. The temple, the shops, and the homes of 
 
 ## Fendalok — Padev
 
-The town's leader, called the **Padev** in Ketulvu tradition. Older man, tall, with a chinstrap beard and the practical bearing of someone who's spent decades doing the work himself. Born in Sulku'it and intends to die in it. He leads by example — joining projects until the rest of the town joins in too. He is the first face new arrivals are likely to see.
+The town's leader, called the **Padev** in Ketulvu tradition. Older man, tall, with a chinstrap beard and the practical bearing of someone who's spent decades doing the work himself. Born in Sulku'it and intends to die in it. It's not uncommon to see him with a hammer or shovel due to his hands-on approach to leadership. Married to **Morna**.
 
 ## Morna — Baker
 
-Married to Fendalok. Runs the bakery on the main square. The town's quiet center — present, capable, the person who steps in when Fendalok's pulled in too many directions. She is steady in a way the town has come to depend on.
+Married to **Fendalok**. Runs the bakery on the main square. The town's quiet center — present, capable, the person who steps in when Fendalok's pulled in too many directions. She is steady in a way the town has come to depend on.
 
 ## Dolan — General Store
 
-Older Ketulvu man, retired officer of the Chaevul military. Spent decades on the road before returning home in his later years. His store carries equipment, supplies, and the occasional curiosity brought in by traveling caravans. His military bearing has never quite left him.
+Runs the general store. If you didn't catch that Dolan is a military man from his bearing, he'll make sure you know by way of stories from his younger days or a misplaced curt order. His store carries equipment, supplies, and the occasional curiosity brought in by traveling caravans.
 
 ## Vetha — Lumberjack
 
-Runs the lumber trade out of her workshop on the edge of town. Inherited the business from Thegan, the old lumberjack who took her on as an apprentice when she was young. She is most herself when working, and the trade reflects it. Took on **Dagwen** as her apprentice.
+Runs the lumber trade out of her workshop on the edge of town. Inherited the business from Thegan, the old lumberjack who took her on as an apprentice when she was young. Took on **Dagwen** as her apprentice. Married to **Fakel**.
 
 ## Fakel — Guard
 
-A Chae soldier stationed in Sulku'it for guard duty. Twenty years on, he is married to Vetha and has made a life here. He keeps the peace with a light hand. Most of the town has come to accept him; some still see only the uniform.
+A Chae soldier stationed in Sulku'it for guard duty. Twenty years on, he is married to **Vetha** and has made a life here. He keeps the peace with a light hand. Most of the town has come to accept him; some still see only the uniform.
 
 ## Kethalis — Blacksmith
 
-Boisterous, social, the kind of presence a town builds an evening around. Inherited the smithy from his mentor Tovanas and has run it since. The smithy is welcoming despite the heat — his doing.
+Boisterous, social, the kind of presence a town builds an evening around. Inherited the smithy from his mentor Tovanas and has run it since. The smithy is welcoming despite the heat — his doing. Married to **Lithona**; father of **Dagwen**.
 
 ## Lithona — Temple Keeper
 
-Born with stark white hair, taken into temple life young. Tends the temple and the traditions of the gods. Will help anyone who comes through her door — healing, listening, advice. Married to Kethalis.
+Born with stark white hair, taken into temple life young. Tends the temple and the traditions of the gods. Will help anyone who comes through her door — healing, listening, advice. Married to **Kethalis**; mother of **Dagwen**.
 
 ## Lomis — Enchanter
 
@@ -84,8 +84,8 @@ A young Ketulvu enchanter with a deep affinity for Sidaev. Discovered his talent
 
 ## Dagwen — Apprentice Lumberjack
 
-Kethalis and Lithona's son. Fourteen, energetic, still finding the shape of who he'll be. Apprenticed to Vetha. He is in the middle of growing up, which is a noisy process.
+Son of **Kethalis** and **Lithona**. Fourteen, energetic. Apprenticed to **Vetha**.
 
 ## Nisra — Aspiring Guard
 
-Vetha and Fakel's daughter. Sixteen. Quiet, watchful, and increasingly drawn to the kind of work her father does — though that's a complicated thing to want in Sulku'it.
+Daughter of **Vetha** and **Fakel**. Sixteen. Quiet, watchful, and increasingly drawn to the kind of work her father does — though that's a complicated thing to want in Sulku'it.

--- a/database/lore/world_player.md
+++ b/database/lore/world_player.md
@@ -1,0 +1,91 @@
+# The World
+
+The **Chaevul Empire** has conquered the region, suppressing older cultures and asserting its own political and philosophical dominance. The empire's reach is long but uneven — the further from the capital, the thinner the control.
+
+**Sulku'it** is a small town on the outskirts of the empire, inhabited primarily by the **Ketulvu** people. It sits near a forest dense with creatures that carry valuable properties — materials, rare drops, and things the wider world has started to take notice of.
+
+The town has become an outpost for those looking to make a name for themselves. People arrive from across the empire — Chae and Ketulvu alike — drawn by opportunity and the chance at something better. Most come with nothing. That's the point. Sulku'it is the kind of place where that's allowed to be enough.
+
+---
+
+# The Chaevul Empire
+
+The empire is ruled by **Emperor Gustavus**. His face is stamped on every korel coin — the most common way most subjects encounter him in their daily lives. He also appears as the king card in standard playing decks across the continent.
+
+The empire's two peoples coexist uneasily in the conquered territories. The **Chae** are the empire's dominant culture: orderly, methodical, given to study and the systematizing of the world. The **Ketulvu** are the people who lived in these lands before the conquest. Their traditions predate the empire by centuries and have not been erased — only forced to share space with it.
+
+---
+
+# Sidaev
+
+**Sidaev** is a force woven through the living world — present in creatures, plants, and people in varying concentrations. Its nature is contested.
+
+The **Ketulvu** regard Sidaev as a gift from their god **Dae**. It is sacred, personal, and alive. To study it is to know something of Dae's intention; to wield it is an act of reverence.
+
+The **Chae** treat Sidaev as a natural force, adjacent to physics or mathematics — a discipline to be understood, measured, and applied. To them it is neither gift nor miracle, simply a property of the world that rewards study.
+
+Both traditions produce practitioners. The tension between them is cultural and philosophical, not always hostile — but it runs deep.
+
+---
+
+# The Gods
+
+The Ketulvu pantheon is older than the empire and quietly resilient. Three names recur most often:
+
+- **Dae** — the source of Sidaev. Honored in every act of crafting, enchanting, and healing that draws on the living force.
+- **Vidali** — the god of life. Patroness of growth, healing, and what endures.
+- **Nokorna** — the god of death. Counterweight to Vidali. The Ketulvu do not regard Nokorna as evil; only as necessary.
+
+The Chae have their own gods, but in the conquered territories most Chae have either set them aside or kept them private. The empire does not officially mandate worship — only loyalty.
+
+---
+
+# Sulku'it
+
+A small Ketulvu town on the empire's frontier, kept alive by its proximity to a Sidaev-rich forest. The town runs on a handful of trades — lumber, smithing, baking, enchanting — and the steady current of newcomers chasing the forest's promise.
+
+The town square is the gathering point. The temple, the shops, and the homes of the people who keep it all running are within a few minutes' walk of each other.
+
+---
+
+# The People of Sulku'it
+
+## Fendalok — Padev
+
+The town's leader, called the **Padev** in Ketulvu tradition. Older man, tall, with a chinstrap beard and the practical bearing of someone who's spent decades doing the work himself. Born in Sulku'it and intends to die in it. He leads by example — joining projects until the rest of the town joins in too. He is the first face new arrivals are likely to see.
+
+## Morna — Baker
+
+Married to Fendalok. Runs the bakery on the main square. The town's quiet center — present, capable, the person who steps in when Fendalok's pulled in too many directions. She is steady in a way the town has come to depend on.
+
+## Dolan — General Store
+
+Older Ketulvu man, retired officer of the Chaevul military. Spent decades on the road before returning home in his later years. His store carries equipment, supplies, and the occasional curiosity brought in by traveling caravans. His military bearing has never quite left him.
+
+## Vetha — Lumberjack
+
+Runs the lumber trade out of her workshop on the edge of town. Inherited the business from Thegan, the old lumberjack who took her on as an apprentice when she was young. She is most herself when working, and the trade reflects it. Took on **Dagwen** as her apprentice.
+
+## Fakel — Guard
+
+A Chae soldier stationed in Sulku'it for guard duty. Twenty years on, he is married to Vetha and has made a life here. He keeps the peace with a light hand. Most of the town has come to accept him; some still see only the uniform.
+
+## Kethalis — Blacksmith
+
+Boisterous, social, the kind of presence a town builds an evening around. Inherited the smithy from his mentor Tovanas and has run it since. The smithy is welcoming despite the heat — his doing.
+
+## Lithona — Temple Keeper
+
+Born with stark white hair, taken into temple life young. Tends the temple and the traditions of the gods. Will help anyone who comes through her door — healing, listening, advice. Married to Kethalis.
+
+## Lomis — Enchanter
+
+A young Ketulvu enchanter with a deep affinity for Sidaev. Discovered his talent as a child when he accidentally turned his hair orange — he's kept it that way ever since. His shop is half workshop, half library. He works late, reads constantly, and lights up when a caravan brings a new tome.
+
+## Dagwen — Apprentice Lumberjack
+
+Kethalis and Lithona's son. Fourteen, energetic, still finding the shape of who he'll be. Apprenticed to Vetha. He is in the middle of growing up, which is a noisy process.
+
+## Nisra — Aspiring Guard
+
+Vetha and Fakel's daughter. Sixteen. Quiet, watchful, and increasingly drawn to the kind of work her father does — though that's a complicated thing to want in Sulku'it.

--- a/database/recipes/enchanter.yaml
+++ b/database/recipes/enchanter.yaml
@@ -15,6 +15,20 @@ recipes:
 
   # EN2 ─────────────────────────────────────────────────────────────────────
 
+  - id: en_spellbook_hiruos
+    name: Spellbook (Hiruos)
+    description: "Bind the pages with refined hiruos — the focus draws on deeper resonance."
+    profession: enchanter
+    required_level: 2
+    ingredients:
+      - item_id: hiruos
+        quantity: 4
+    output:
+      type: weapon
+      id: spellbook
+      base_bonus:
+        attack: 1
+
   - id: en_hiruos
     name: Hiruos
     description: "Distill raw thuvel into refined hiruos — the enchanter's primary working material."
@@ -112,6 +126,22 @@ recipes:
       type: item
       id: nodol
       quantity: 1
+
+  - id: en_spellbook_nodol
+    name: Spellbook (Nodol)
+    description: "Reforge the spellbook around a nodol crystal — every page hums."
+    profession: enchanter
+    required_level: 7
+    ingredients:
+      - item_id: nodol
+        quantity: 2
+    output:
+      type: weapon
+      id: spellbook
+      base_bonus:
+        defend: 1
+        attack: 1
+        special: 1
 
   - id: en_kustaff_nodol
     name: Kustaff (Nodol)

--- a/database/shops/blacksmith.yaml
+++ b/database/shops/blacksmith.yaml
@@ -12,7 +12,7 @@ Items:
     R_Max: 3.4
     Volume_Sensitivity: 50
     Transaction_Threshold: 15
-    Stock_Max: 500
+    Stock_Max: 2000
     Stock_Influence: 0.2
     Restock_Field: [15, 25, 30, 40, 0]
 
@@ -193,6 +193,6 @@ Items:
     R_Max: 3.99
     Volume_Sensitivity: 30
     Transaction_Threshold: 12
-    Stock_Max: 300
+    Stock_Max: 1000
     Stock_Influence: 0.15
     Restock_Field: [15, 25, 30, 40, 0]

--- a/database/shops/enchanting_shop.yaml
+++ b/database/shops/enchanting_shop.yaml
@@ -11,7 +11,7 @@ Items:
     R_Max: 3.4
     Volume_Sensitivity: 50
     Transaction_Threshold: 15
-    Stock_Max: 500
+    Stock_Max: 2000
     Stock_Influence: 0.2
     Restock_Field: [15, 25, 30, 40, 0]
 
@@ -23,7 +23,7 @@ Items:
     R_Max: 3.4
     Volume_Sensitivity: 20
     Transaction_Threshold: 10
-    Stock_Max: 200
+    Stock_Max: 800
     Stock_Influence: 0.2
     Restock_Field: [6, 10, 12, 16, 0]
 

--- a/database/shops/general_store.yaml
+++ b/database/shops/general_store.yaml
@@ -101,7 +101,7 @@ Items:
     R_Max: 3.99
     Volume_Sensitivity: 100
     Transaction_Threshold: 20
-    Stock_Max: 1000
+    Stock_Max: 2000
     Stock_Influence: 0.1
     Restock_Field: [40, 60, 80, 100, 0]
 
@@ -112,7 +112,7 @@ Items:
     R_Max: 3.99
     Volume_Sensitivity: 30
     Transaction_Threshold: 10
-    Stock_Max: 200
+    Stock_Max: 800
     Stock_Influence: 0.2
     Restock_Field: [10, 15, 20, 25, 0]
 
@@ -123,6 +123,6 @@ Items:
     R_Max: 3.99
     Volume_Sensitivity: 10
     Transaction_Threshold: 5
-    Stock_Max: 50
+    Stock_Max: 200
     Stock_Influence: 0.35
     Restock_Field: [1, 2, 2, 3, 0]

--- a/database/shops/lumberjack.yaml
+++ b/database/shops/lumberjack.yaml
@@ -12,7 +12,7 @@ Items:
     R_Max: 3.4
     Volume_Sensitivity: 50
     Transaction_Threshold: 15
-    Stock_Max: 500
+    Stock_Max: 2000
     Stock_Influence: 0.2
     Restock_Field: [15, 25, 30, 40, 0]
 
@@ -227,7 +227,7 @@ Items:
     R_Max: 3.99
     Volume_Sensitivity: 80
     Transaction_Threshold: 15
-    Stock_Max: 500
+    Stock_Max: 1000
     Stock_Influence: 0.15
     Restock_Field: [15, 25, 30, 40, 0]
 
@@ -260,6 +260,6 @@ Items:
     R_Max: 3.99
     Volume_Sensitivity: 80
     Transaction_Threshold: 12
-    Stock_Max: 300
+    Stock_Max: 1000
     Stock_Influence: 0.15
     Restock_Field: [15, 25, 30, 40, 0]

--- a/database/weapons/axe_talamite.yaml
+++ b/database/weapons/axe_talamite.yaml
@@ -2,6 +2,7 @@ Name: Talamite Axe
 Description: Heavy and unforgiving. The talamite head takes an edge that sulwood never could.
 Level: 4
 HP: 65
+Weight: 0
 
 Resource:
   Name: Strength

--- a/database/weapons/axe_wood.yaml
+++ b/database/weapons/axe_wood.yaml
@@ -2,6 +2,7 @@
 Description: Heavy and unforgiving. Put your whole body into it and it shows.
 Level: 3
 HP: 55
+Weight: 0
 
 Resource:
   Name: Strength

--- a/database/weapons/bow.yaml
+++ b/database/weapons/bow.yaml
@@ -2,6 +2,7 @@ Name: Bow
 Description: A simple bow strung with sulwood. Keeps enemies at a distance, but you'll need to watch your quiver.
 Level: 3
 HP: 25
+Weight: 0
 
 Resource:
   Name: Quiver

--- a/database/weapons/branch.yaml
+++ b/database/weapons/branch.yaml
@@ -2,6 +2,7 @@ Name: Branch
 Description: A sturdy fallen branch. Not much, but it'll do.
 Level: 1
 HP: 30
+Weight: 0
 
 Resource:
   Name: Integrity

--- a/database/weapons/dagger.yaml
+++ b/database/weapons/dagger.yaml
@@ -2,6 +2,7 @@ Name: Dagger
 Description: A slim talamite blade, quick in the hand. Keep it close or throw it — either way, it draws blood.
 Level: 2
 HP: 30
+Weight: 0
 
 Resource:
   Name: Poise

--- a/database/weapons/deck_of_cards.yaml
+++ b/database/weapons/deck_of_cards.yaml
@@ -2,6 +2,7 @@ Name: Deck of Cards
 Description: The cards in this deck are razor sharp and fly with precision. An worthy weapon for any adventurer.
 Level: 3
 HP: 25
+Weight: 0
 
 Resource:
   Name: Luck

--- a/database/weapons/honor.yaml
+++ b/database/weapons/honor.yaml
@@ -1,6 +1,7 @@
 Name: Honor
 Description: Virtue made manifest.
 HP: 1000
+Weight: 0
 Resource:
   Name: Virtue
   Max: 100

--- a/database/weapons/kustaff.yaml
+++ b/database/weapons/kustaff.yaml
@@ -2,6 +2,7 @@ Name: Kustaff
 Description: A quarterstaff woven through with living vines and hardened thorns. It grows, constricts, and reflects — the wood doesn't end where the plant begins.
 Level: 3
 HP: 60
+Weight: 0
 
 Resource:
   Name: Connection

--- a/database/weapons/mace.yaml
+++ b/database/weapons/mace.yaml
@@ -2,6 +2,7 @@ Name: Mace
 Description: A dense talamite mace. Once it gets moving, hard to stop — and hard to get away from.
 Level: 3
 HP: 80
+Weight: 0
 
 Resource:
   Name: Momentum

--- a/database/weapons/mental_cage.yaml
+++ b/database/weapons/mental_cage.yaml
@@ -2,6 +2,7 @@ Name: Mental Cage
 Description: A lattice of psychic force worn on the mind — invisible to anyone else, crushing to its wearer's enemies. It does not bind you. It binds them.
 Level: 3
 HP: 30
+Weight: 0
 
 Resource:
   Name: Tranquility

--- a/database/weapons/quarterstaff.yaml
+++ b/database/weapons/quarterstaff.yaml
@@ -2,6 +2,7 @@ Name: Quarterstaff
 Description: A smooth length of sulwood, balanced for reach and control. Simple to make, hard to master.
 Level: 2
 HP: 35
+Weight: 0
 
 Resource:
   Name: Balance

--- a/database/weapons/shovel_talamite.yaml
+++ b/database/weapons/shovel_talamite.yaml
@@ -2,6 +2,7 @@ Name: Talamite Shovel
 Description: The talamite blade stays sharp no matter the abuse. Same rhythm, just hits harder.
 Level: 4
 HP: 70
+Weight: 0
 
 Resource:
   Name: Stamina

--- a/database/weapons/shovel_wood.yaml
+++ b/database/weapons/shovel_wood.yaml
@@ -2,6 +2,7 @@
 Description: A rusty shovel with a few knicks in the cutting edge. It has obviously served another fighter well.
 Level: 3
 HP: 60
+Weight: 0
 
 Resource:
   Name: Stamina

--- a/database/weapons/spellbook.yaml
+++ b/database/weapons/spellbook.yaml
@@ -2,6 +2,7 @@ Name: Spellbook
 Description: A tome of bound spells — each page a strike, each chapter a strategy.
 Level: 2
 HP: 35
+Weight: 0
 
 Resource:
   Name: Pages

--- a/database/weapons/sword_talamite.yaml
+++ b/database/weapons/sword_talamite.yaml
@@ -2,6 +2,7 @@ Name: Talamite Sword
 Description: A well-balanced talamite blade. The edge holds far longer than sulwood — let it work.
 Level: 4
 HP: 55
+Weight: 0
 
 Resource:
   Name: Sharpness

--- a/database/weapons/sword_wood.yaml
+++ b/database/weapons/sword_wood.yaml
@@ -2,6 +2,7 @@
 Description: A well-balanced blade. Sharpness is everything â€” let it dull and you'll feel it.
 Level: 3
 HP: 45
+Weight: 0
 
 Resource:
   Name: Sharpness

--- a/database/weapons/wand.yaml
+++ b/database/weapons/wand.yaml
@@ -2,6 +2,7 @@ Name: Wand
 Description: A slender sulwood rod attuned to the elements. Bolts share a source but land differently.
 Level: 3
 HP: 15
+Weight: 0
 
 Resource:
   Name: Sidaev

--- a/database/weapons/wand_talamite.yaml
+++ b/database/weapons/wand_talamite.yaml
@@ -2,6 +2,7 @@ Name: Talamite Wand
 Description: A wand of talamite. Cold and dense where sulwood is warm — the elements don't care which it is.
 Level: 3
 HP: 15
+Weight: 0
 
 Resource:
   Name: Sidaev

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,20 @@
 The detailed, dev-side log. The condensed, player-facing version that goes
 to the Discord #updates channel lives at `docs/CHANGELOG_DISCORD.md`.
 
+## 0.1.5 — unreleased
+
+### Shop Stock
+- **Hourly destock loop** — `TICK_INTERVAL_MS` (24h) blocked the destock from firing more than once per day per item, so popular shelves (venison, thuvel, hiruos, maek_egg seen pinned at cap on prod) waited hours-to-a-full-day before any flush. Split into two clocks: daily tick still owns price update + low-stock restock, new `maybeHourlyDestock` runs on the same hourly walk and dumps `6× rolled Restock_Field` whenever stock ≥ 75% of cap. In-memory `lastDestockAt` map gates one destock per item per hour (lost on restart — acceptable, restart just triggers a fresh round of catch-up flushes).
+- **Stock_Max bumps on hot items** to give shelves real headroom under multi-player load:
+  - venison 200 → 800, maek_egg 50 → 200 (general store)
+  - thuvel 500 → 2000, hiruos 200 → 800 (enchanter)
+  - swallow_feather 1000 → 2000 (general store)
+  - crude_talamite 500 → 2000 (blacksmith), sulwood 500 → 2000 (lumberjack)
+  - melstone 300 → 1000 (blacksmith)
+  - felt_hat 500 → 1000, bottle_of_tar 300 → 1000 (lumberjack)
+
+---
+
 ## 0.1.4 — 2026-06-03
 
 Mobile-friendly UI, keyboard combat controls, the Golnosar joins the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,17 +3,169 @@
 The detailed, dev-side log. The condensed, player-facing version that goes
 to the Discord #updates channel lives at `docs/CHANGELOG_DISCORD.md`.
 
-## 0.1.5 — unreleased
+## 0.1.5 — 2026-06-05
 
-### Shop Stock
-- **Hourly destock loop** — `TICK_INTERVAL_MS` (24h) blocked the destock from firing more than once per day per item, so popular shelves (venison, thuvel, hiruos, maek_egg seen pinned at cap on prod) waited hours-to-a-full-day before any flush. Split into two clocks: daily tick still owns price update + low-stock restock, new `maybeHourlyDestock` runs on the same hourly walk and dumps `6× rolled Restock_Field` whenever stock ≥ 75% of cap. In-memory `lastDestockAt` map gates one destock per item per hour (lost on restart — acceptable, restart just triggers a fresh round of catch-up flushes).
-- **Stock_Max bumps on hot items** to give shelves real headroom under multi-player load:
+The "fill in the docs and rebuild combat for teams" release. Three new info
+pages (Lore, Reference, About), a full multi-combatant rewrite for combat
+with DnD-style initiative, multi-enemy hunts on a much larger board, and a
+big infrastructure pass to make the prod stack reliable.
+
+### Combat — multi-combatant rewrite
+
+The combat engine no longer assumes 1-vs-1. The architecture now generalizes
+to N-vs-M with a single initiative system driving everything — a deliberate
+stepping stone toward eventual PVP.
+
+- **Initiative system** (DnD-style). Each combatant rolls `(1..100) − Weight`
+  at battle start. Higher score acts first; ties resolved by "player beats
+  NPC" then coin flip. Initiative ordering applies to action sub-phases
+  (defend/attack/special), DOT ticks, and contested-tile movement priority
+  — replaces the old hardcoded "player first" / "AI DOT first" / `isAI`
+  movePriority rules. Initiative rolls log to the combat log on `join_session`
+  (and persist as a synthetic "round 0" in the battle log).
+- **Weight stat** on every weapon (YAML `Weight:` field) and on every enemy
+  weapon. All weights currently `0` — per-weapon tuning is its own balance
+  pass. Even at 0 weight the random roll spreads combatants across the
+  initiative order.
+- **Multi-enemy spawn**. 2.3% chance of a 2-enemy spawn on bait consumption.
+  Two enemies get `A`/`B` name suffixes (e.g. `Melbear A`, `Melbear B`) for
+  log disambiguation. Each spawn picks a random pattern start index so
+  identical enemies don't telegraph identical actions on turn 1.
+- **Dev `+2 (dev)` button** on each bait card (gated server-side by
+  `isDev(discordId)`) forces a 2-spawn for testing without waiting on the
+  2.3% roll.
+- **Per-enemy loot** — each defeated enemy rolls its own loot table; results
+  merge into one summary so the existing victory UI is unchanged.
+- **Re-route algorithm changed** — when a combatant loses a contested move,
+  it now re-routes toward its *original destination* (not the nearest enemy
+  as before), which approximates "stop on the path you planned" when the
+  blocking enemy is one tile ahead. Used `<=` for the tile comparator so the
+  combatant will step toward the destination when chebyshev distance is tied
+  (the "tile right before the blocker" case).
+- **Conflict log reworded** — `X yields to Y.` → `X's path to (a,b) blocked
+  by Y.`. The old "tie — neither moves" message is gone (unreachable now
+  that initiative ranks are unique).
+
+### Combat — board redesign
+
+- **12×10 hunt board** (was 7×5). 120 tiles vs 35.
+- **Random player spawn** in the top-left 5×5 box.
+- **Distance-based enemy spawn**. Random chebyshev distance 6–8 at a random
+  angle from the player. Two enemies maintain ≥ 3 chebyshev separation from
+  each other.
+- **Obstacle generation**: count sampled from a normal distribution (mean
+  10, stddev 4, clamped 3–25). 3×3 buffer around every spawn tile so nothing
+  is pinned in immediately. BFS verifies every enemy is reachable from the
+  player; layouts that wall enemies off are re-rolled.
+- **Tutorial board unchanged** — still the fixed 6×2 mini-layout.
+- **Cell size tuned**: 72px → 48px desktop, 44px → 28px mobile. The 12-wide
+  board is now 576px on desktop, 336px on mobile (fits a typical phone).
+
+### Info pages
+
+Three new pages under the **Info** sidebar group, all rendered from markdown
+under `database/lore/` and `database/docs/`:
+
+- **Lore** (`/app/lore`) — curated player-facing world doc: world background,
+  the Chaevul Empire, Sidaev, the gods, Sulku'it, and town-introduction style
+  NPC blurbs. Sidebar of sections, detail panel on the right. Designer-facing
+  `world.md` is kept separate so personal NPC notes / spoilers don't leak.
+- **Reference** (`/app/reference`) — game terms reference: Currency & Stats,
+  Combat Actions, Damage & Resistances, The Battle, Hunting, Town Shops, The
+  Bench, Professions, Trading, Weapons, Items, and a Glossary that links
+  back to every section. Includes nested-list + table + intra-page anchor
+  link support in the markdown renderer.
+- **About** (`/app/about`) — single-section narrative page from the dev about
+  the game's origin and design intent.
+
+The renderer used by Lore/Reference picked up support for tables, nested
+bullet lists, numbered lists, `code` spans, and intra-page anchor links
+(`[Term](#section-slug)` jumps to the linked section via the SPA's section
+selector instead of doing a full navigation).
+
+### Crafting / recipes
+
+- **Spellbook tier-2 and tier-3 recipes added**. Spellbook was the only L1
+  weapon missing higher-tier variants:
+  - `Spellbook (Hiruos)` at Enchanter level 2 → spellbook with +1 attack
+    baked in (mirrors Quarterstaff (Treated) and Dagger (Talamite))
+  - `Spellbook (Nodol)` at Enchanter level 7 → spellbook with +1 def/+1 atk/
+    +1 spec baked in (mirrors Kustaff (Nodol) and Mental Cage (Nodol))
+
+### Shop economy
+
+- **Hourly destock loop**. `TICK_INTERVAL_MS` (24h) blocked the destock from
+  firing more than once per day per item, so popular shelves (venison,
+  thuvel, hiruos, maek_egg pinned at cap on prod) waited hours-to-a-day for
+  any flush. Split into two clocks: daily tick still owns price update +
+  low-stock restock; new `maybeHourlyDestock` runs on the same hourly walk
+  and dumps `6 × rolled Restock_Field` whenever stock ≥ 75% of cap. In-memory
+  `lastDestockAt` map gates one destock per item per hour (lost on restart —
+  acceptable, restart just triggers a fresh round of catch-up flushes).
+- **Stock_Max bumps on hot items**:
   - venison 200 → 800, maek_egg 50 → 200 (general store)
   - thuvel 500 → 2000, hiruos 200 → 800 (enchanter)
   - swallow_feather 1000 → 2000 (general store)
   - crude_talamite 500 → 2000 (blacksmith), sulwood 500 → 2000 (lumberjack)
   - melstone 300 → 1000 (blacksmith)
   - felt_hat 500 → 1000, bottle_of_tar 300 → 1000 (lumberjack)
+- **SHOP_DIR TDZ fix** — `runShopTick()` was being invoked synchronously at
+  module load before `SHOP_DIR` was declared, so the hourly shop tick had
+  been silently failing on prod every hour since 0.1.3 with
+  `ReferenceError: Cannot access 'SHOP_DIR' before initialization`. Deferred
+  to `setImmediate(...)` so SHOP_DIR is bound before the first tick. Means
+  the new hourly destock loop will *actually run* on prod.
+- **Volume columns → BigInt**. `cumulative_volume` + `recent_volume` on
+  `ShopItemState` were INT4 (ceiling 2.1B). The infinite `swallow_bait`
+  tutorial item drove `cumulative_volume` past INT4 in testing and broke
+  buy/sell on prod with a "Unable to fit integer value '2147483648' into
+  an INT4" Prisma error. Widened to BigInt; math sites coerce to Number
+  (values stay far below MAX_SAFE_INTEGER).
+
+### Diagnostics
+
+- **Express request logging** — middleware emits one line per dynamic
+  request: `[req] 2026-06-05T01:32:43.277Z 1.2.3.4 GET /url 200 13ms`. Static
+  asset hits are skipped unless they 4xx/5xx. CF-Connecting-IP preferred over
+  socket peer so the IP is the real client.
+- **Client error capture** — new `POST /api/client_error` endpoint plus
+  `public/error-capture.js` wires `window.error` + `unhandledrejection` to
+  POST `{url, message, source, line, col, stack, ua}`. Throttled to one
+  POST per message per minute. Uses `sendBeacon` when available so capture
+  survives page unload. Loaded by both `app.html` and `index.html`. Lets us
+  remotely diagnose white screens / SPA crashes without devtools on the
+  user's end.
+- **Webhook script gets request logging**. `webhook/index.js` now logs
+  every incoming GitHub delivery with method, URL, IP, UA, delivery ID, and
+  the routing decision (`-> 200 (deploy dev)`, `-> 401 (bad signature)`,
+  `-> 404 (method/url mismatch)`, etc.). Cross-references with the
+  cloudflared journal made the "intermittent webhook 404s" debug session
+  tractable.
+- **Discord interaction listener consolidation**. 12 separate
+  `client.on(InteractionCreate, ...)` registrations consolidated into one
+  dispatcher backed by an `interactionHandlers[]` array. Each handler still
+  owns its own filter (`isChatInputCommand && commandName === 'X'`) and
+  early-returns when not addressed. Error in one handler doesn't break the
+  siblings (each call wrapped in try/catch). Killed the
+  `MaxListenersExceededWarning` that fired on every restart.
+
+### Infrastructure
+
+- **Cloudflared tunnel consolidation**. Discovered a second `cloudflared`
+  instance on the `proxy` VM running an older config with non-overlapping
+  hostname rules (handled `webhook.slowb.rodeo` + `foundry.slowb.rodeo`,
+  but no `idya.slowb.rodeo` route). Cloudflare load-balanced incoming
+  requests across both replicas, which meant about half of all hits to
+  `idya.slowb.rodeo` 404'd at the catch-all on the proxy replica, and
+  half of all hits to `webhook.slowb.rodeo` 404'd on the db-server
+  replica. Classic intermittent-404 pattern across all 0.1.x. Fix:
+  consolidated all hostnames into the db-server `cloudflared` config
+  (`idya`, `webhook`, `foundry` all point at `localhost:9000/3001` or
+  `10.0.0.3:30000`), stopped + disabled cloudflared on the proxy box.
+- **Cloudflared 2026.5.2 upgrade** on db-server with `edge-ip-version: "4"`
+  pinned in config — the 2026.5.2 default of `auto` prefers IPv6, which is
+  asymmetrically broken on the prod ISP and caused a brief total outage
+  during the upgrade until pinned to v4.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ react to player trading.
 - **Battle keyboard input** — arrow keys move (or click-target), `1`–`9` selects action by index, `Enter` confirms / skips / returns to town. Hunt page also accepts `Enter` to confirm bait selection.
 
 ### New Content
-- **New enemy: Golnosar** (Level 4, 110 HP). Pool-dwelling living-tar creature. Resource: Tar (max 10). Tar Drink (defend, blocks 10 + restores 10 Tar), Tar Shot (attack, reactive, range 3, swingy 0–8 blunt), Blind crit (DOT, 10 per round for 3 rounds), Fistar (special, aimed, range 4, arcane fire DOT 5–14 for 5 rounds). 8-step pattern (drink → 4× shot → fistar → 2× shot). Sim shows ~40% win rate on Talamite Axe/Shovel with 50% aim-miss assumption.
+- **New enemy: Golnosar** (Level 4, 110 HP). Pool-dwelling living-tar creature. Resource: Tar (max 10). Tar Drink (defend, blocks 10 + restores 10 Tar), Tar Shot (attack, reactive, range 1, swingy 0–8 blunt), Blind crit (DOT, 10 per round for 3 rounds), Fistar (special, aimed, range 4, arcane fire DOT 5–14 for 5 rounds). 8-step pattern (drink → 4× shot → fistar → 2× shot). Sim shows ~40% win rate on Talamite Axe/Shovel with 50% aim-miss assumption. (Post-release tweak: Tar Shot range dropped 3 → 1 — was too punishing as a reactive ranged attack; melee-only forces the golnosar to close before it can spit.)
 - **Tar Bait** at the general store (60 buy / 18 sell). Summons Golnosar.
 - **Bottle of Tar** drops to the lumberjack (90/30, used for waterproofing).
 - **Lifgem** drops as a rare valuable (1-in-20 from Golnosar). Goes to the enchanter (800/400). Priced for "will become more common when other enemies drop it" — moderate stock cap, modest unit value.

--- a/docs/CHANGELOG_DISCORD.md
+++ b/docs/CHANGELOG_DISCORD.md
@@ -2,6 +2,19 @@
 
 Condensed, player-facing changelog posted to the #updates channel on each new release. For full detail see `docs/CHANGELOG.md`.
 
+## 0.1.5 — 2026-06-05
+
+- New info pages: **Lore**, **Reference**, and **About** in the sidebar.
+- Hunts now happen on a bigger board (12×10) with random player + enemy spawns and randomly placed obstacles.
+- Small chance (2.3%) a bait pulls a second enemy with it. Both drop loot.
+- Combat turn order is now decided by an **initiative** roll at the start of each battle — higher roll acts first, even between enemies.
+- **Spellbook** now has Tier-2 (Hiruos) and Tier-3 (Nodol) recipes like the other starting weapons.
+- Shop shelves now flush popular items every hour, so the world keeps moving when items pile up.
+- Stock caps raised on the most-traded items so shops don't choke as more players hunt.
+- Webhook + tunnel reliability fixes — the intermittent 404s and missed deploys across 0.1.x should be largely gone.
+
+---
+
 ## 0.1.4 — 2026-06-03
 
 - Something new is stirring in the tar pools. Bring a bait that matches.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "//3": "updating this file will download and update your packages",
   "name": "idya",
   "type": "module",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "RPG Bot",
   "author": "pg805",
   "main": "./src/discord/init.ts",

--- a/prisma/migrations/20260604160000_volumes_to_bigint/migration.sql
+++ b/prisma/migrations/20260604160000_volumes_to_bigint/migration.sql
@@ -1,0 +1,8 @@
+-- Widen ShopItemState.cumulative_volume and recent_volume from INT4 to BIGINT
+-- so they don't overflow. Tutorial/test traffic on Infinite items can drive
+-- cumulative_volume past 2.1B (INT4 ceiling) and break buy/sell transactions
+-- with a "ConversionError: Unable to fit integer value '2147483648' into an
+-- INT4" Prisma error. recent_volume self-decays at 0.7/tick so it rarely
+-- climbs alone, but we widen it too for symmetry.
+ALTER TABLE "ShopItemState" ALTER COLUMN "cumulative_volume" TYPE BIGINT;
+ALTER TABLE "ShopItemState" ALTER COLUMN "recent_volume" TYPE BIGINT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,8 +105,8 @@ model ShopItemState {
   item_id           String
   x                 Float    @default(0.5)
   stock             Int      @default(0)
-  cumulative_volume Int      @default(0)
-  recent_volume     Int      @default(0)
+  cumulative_volume BigInt   @default(0)
+  recent_volume     BigInt   @default(0)
   last_tick         DateTime @default(now())
 
   @@id([shop_id, item_id])

--- a/public/app.html
+++ b/public/app.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="/views/bench.css">
   <link rel="stylesheet" href="/views/professions.css">
   <link rel="stylesheet" href="/views/enemies.css">
+  <link rel="stylesheet" href="/views/lore.css">
   <link rel="stylesheet" href="/views/hunt.css">
   <link rel="stylesheet" href="/views/trade.css">
   <link rel="stylesheet" href="/views/create.css">
@@ -53,6 +54,7 @@
         <a class="nav-link" data-path="/professions">Professions</a>
         <a class="nav-link" data-path="/enemies">Enemies</a>
         <a class="nav-link" data-path="/weapon-stats">Weapon Stats</a>
+        <a class="nav-link" data-path="/lore">Lore</a>
       </div>
     </nav>
 
@@ -72,6 +74,7 @@
   <script src="/views/enchant.js"></script>
   <script src="/views/professions.js"></script>
   <script src="/views/enemies.js"></script>
+  <script src="/views/lore.js"></script>
   <script src="/views/hunt.js"></script>
   <script src="/views/trade.js"></script>
   <script src="/views/trade-start.js"></script>

--- a/public/app.html
+++ b/public/app.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="/views/professions.css">
   <link rel="stylesheet" href="/views/enemies.css">
   <link rel="stylesheet" href="/views/lore.css">
+  <link rel="stylesheet" href="/views/about.css">
   <link rel="stylesheet" href="/views/hunt.css">
   <link rel="stylesheet" href="/views/trade.css">
   <link rel="stylesheet" href="/views/create.css">
@@ -56,6 +57,7 @@
         <a class="nav-link" data-path="/weapon-stats">Weapon Stats</a>
         <a class="nav-link" data-path="/lore">Lore</a>
         <a class="nav-link" data-path="/reference">Reference</a>
+        <a class="nav-link" data-path="/about">About</a>
       </div>
     </nav>
 
@@ -78,6 +80,7 @@
   <script src="/views/enemies.js"></script>
   <script src="/views/lore.js"></script>
   <script src="/views/reference.js"></script>
+  <script src="/views/about.js"></script>
   <script src="/views/hunt.js"></script>
   <script src="/views/trade.js"></script>
   <script src="/views/trade-start.js"></script>

--- a/public/app.html
+++ b/public/app.html
@@ -55,6 +55,7 @@
         <a class="nav-link" data-path="/enemies">Enemies</a>
         <a class="nav-link" data-path="/weapon-stats">Weapon Stats</a>
         <a class="nav-link" data-path="/lore">Lore</a>
+        <a class="nav-link" data-path="/reference">Reference</a>
       </div>
     </nav>
 
@@ -76,6 +77,7 @@
   <script src="/views/professions.js"></script>
   <script src="/views/enemies.js"></script>
   <script src="/views/lore.js"></script>
+  <script src="/views/reference.js"></script>
   <script src="/views/hunt.js"></script>
   <script src="/views/trade.js"></script>
   <script src="/views/trade-start.js"></script>

--- a/public/app.html
+++ b/public/app.html
@@ -61,6 +61,7 @@
     <main id="app-content"></main>
   </div>
 
+  <script src="/error-capture.js"></script>
   <script src="/auth.js"></script>
   <script src="/layout.js"></script>
   <script src="/tour.js"></script>

--- a/public/app.js
+++ b/public/app.js
@@ -17,6 +17,7 @@ function routeFromPath(path) {
   if (path === '/professions')          return { viewName: 'professions', params: {} };
   if (path === '/enemies')              return { viewName: 'enemies', params: {} };
   if (path === '/lore')                 return { viewName: 'lore',    params: {} };
+  if (path === '/reference')            return { viewName: 'reference', params: {} };
   if (path === '/hunt')                 return { viewName: 'hunt',    params: {} };
   if (path === '/trade')                return { viewName: 'trade-start', params: {} };
   if (path === '/create')               return { viewName: 'create',  params: {} };

--- a/public/app.js
+++ b/public/app.js
@@ -16,6 +16,7 @@ function routeFromPath(path) {
   if (path === '/enchant')              return { viewName: 'enchant', params: {} };
   if (path === '/professions')          return { viewName: 'professions', params: {} };
   if (path === '/enemies')              return { viewName: 'enemies', params: {} };
+  if (path === '/lore')                 return { viewName: 'lore',    params: {} };
   if (path === '/hunt')                 return { viewName: 'hunt',    params: {} };
   if (path === '/trade')                return { viewName: 'trade-start', params: {} };
   if (path === '/create')               return { viewName: 'create',  params: {} };

--- a/public/app.js
+++ b/public/app.js
@@ -18,6 +18,7 @@ function routeFromPath(path) {
   if (path === '/enemies')              return { viewName: 'enemies', params: {} };
   if (path === '/lore')                 return { viewName: 'lore',    params: {} };
   if (path === '/reference')            return { viewName: 'reference', params: {} };
+  if (path === '/about')                return { viewName: 'about',     params: {} };
   if (path === '/hunt')                 return { viewName: 'hunt',    params: {} };
   if (path === '/trade')                return { viewName: 'trade-start', params: {} };
   if (path === '/create')               return { viewName: 'create',  params: {} };

--- a/public/error-capture.js
+++ b/public/error-capture.js
@@ -1,0 +1,52 @@
+// Catches unhandled JS errors + promise rejections and forwards them to the
+// server (which logs to stdout / PM2). Runs before any view code so it can
+// catch early-init crashes that produce a white screen.
+//
+// Throttled to one POST per error message per minute to avoid flooding the
+// server if a render loop is spewing the same error.
+(function() {
+  const recent = new Map();   // message -> last posted timestamp
+  const COOLDOWN_MS = 60_000;
+
+  function post(payload) {
+    const key = String(payload.message ?? '').slice(0, 200);
+    const now = Date.now();
+    const last = recent.get(key) ?? 0;
+    if (now - last < COOLDOWN_MS) return;
+    recent.set(key, now);
+    try {
+      // sendBeacon survives page unload; falls back to fetch if unavailable.
+      const body = JSON.stringify(payload);
+      if (navigator.sendBeacon) {
+        navigator.sendBeacon('/api/client_error', new Blob([body], { type: 'application/json' }));
+      } else {
+        fetch('/api/client_error', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body,
+          keepalive: true,
+        }).catch(() => {});
+      }
+    } catch (_) { /* swallow — capture must never crash the page */ }
+  }
+
+  window.addEventListener('error', (e) => {
+    post({
+      url:     location.href,
+      message: e.message || (e.error && e.error.message) || 'error event',
+      source:  e.filename,
+      line:    e.lineno,
+      col:     e.colno,
+      stack:   e.error && e.error.stack,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', (e) => {
+    const reason = e.reason;
+    post({
+      url:     location.href,
+      message: 'unhandledrejection: ' + (reason && reason.message ? reason.message : String(reason)),
+      stack:   reason && reason.stack,
+    });
+  });
+})();

--- a/public/game.css
+++ b/public/game.css
@@ -1,6 +1,6 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
-:root { --cell-size: 72px; }
+:root { --cell-size: 48px; }
 
 body {
   background: var(--bg);
@@ -359,7 +359,7 @@ h1 { color: var(--gold); letter-spacing: 0.12em; font-size: 1.3rem; }
    fits inside a ~390px viewport without overflow. The js-driven width on
    #left-col is overridden with !important since it's set inline. */
 @media (max-width: 640px) {
-  :root { --cell-size: 44px; }
+  :root { --cell-size: 28px; }
   #battle-shell { padding: 8px; gap: 8px; }
   #main-layout {
     flex-direction: column;

--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,7 @@
     </div>
   </div>
 
+  <script src="/error-capture.js"></script>
   <script src="/auth.js"></script>
   <script src="/layout.js"></script>
   <script src="/socket.io/socket.io.js"></script>

--- a/public/views/about.css
+++ b/public/views/about.css
@@ -1,0 +1,19 @@
+/* View: About — single-column narrative, centered article */
+
+.about-body {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  justify-content: center;
+  padding: 40px 24px 60px;
+}
+
+.about-body .lore-article {
+  max-width: 680px;
+  width: 100%;
+}
+
+.about-body .lore-article p {
+  margin-bottom: 16px;
+  line-height: 1.7;
+}

--- a/public/views/about.js
+++ b/public/views/about.js
@@ -1,0 +1,64 @@
+// View: About — single-section narrative page. Reuses the lore-article
+// styles for type/spacing.
+(function() {
+  function esc(s) {
+    return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function formatInline(s) {
+    return esc(s)
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, '$1<em>$2</em>');
+  }
+
+  // Tiny markdown -> HTML; same shape as lore.js, no tables / lists needed
+  // for the About copy.
+  function renderMarkdown(md) {
+    const lines = md.split(/\r?\n/);
+    const out = [];
+    let paragraph = [];
+    const flushParagraph = () => {
+      if (paragraph.length === 0) return;
+      const text = paragraph.join(' ').trim();
+      if (text) out.push(`<p>${formatInline(text)}</p>`);
+      paragraph = [];
+    };
+    for (const raw of lines) {
+      const line = raw.replace(/\s+$/, '');
+      if (/^---+$/.test(line.trim())) { flushParagraph(); out.push('<hr>'); continue; }
+      const h2 = line.match(/^## (.+)$/);
+      if (h2) { flushParagraph(); out.push(`<h2>${formatInline(h2[1])}</h2>`); continue; }
+      if (line.trim() === '') { flushParagraph(); continue; }
+      paragraph.push(line);
+    }
+    flushParagraph();
+    return out.join('\n');
+  }
+
+  async function mount(root) {
+    setLayoutTitle('About');
+    root.innerHTML = `<div class="about-body"><p class="lore-hint">Loading…</p></div>`;
+    const res = await fetch('/api/info/about');
+    if (!res.ok) {
+      root.querySelector('.about-body').innerHTML = `<p class="lore-hint">Could not load.</p>`;
+      return;
+    }
+    const data = await res.json();
+    const section = data.sections[0];
+    if (!section) {
+      root.querySelector('.about-body').innerHTML = `<p class="lore-hint">No content.</p>`;
+      return;
+    }
+    root.querySelector('.about-body').innerHTML = `
+      <article class="lore-article">
+        <h1>${esc(section.title)}</h1>
+        ${renderMarkdown(section.body)}
+      </article>
+    `;
+  }
+
+  function unmount() {}
+
+  window.Views = window.Views ?? {};
+  window.Views.about = { mount, unmount };
+})();

--- a/public/views/hunt.css
+++ b/public/views/hunt.css
@@ -148,6 +148,26 @@
   cursor: default;
 }
 
+.hunt-card-actions {
+  margin-top: auto;
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+}
+.hunt-card-actions .hunt-start { margin-top: 0; flex: 1; }
+.hunt-card-actions .hunt-start-dev {
+  flex: 0 0 auto;
+  background: var(--gold-bg, var(--bg-deep));
+  border-color: var(--gold);
+  color: var(--gold);
+  font-size: 0.75rem;
+  padding: 8px 10px;
+}
+.hunt-card-actions .hunt-start-dev:hover:not(:disabled) {
+  background: var(--gold);
+  color: var(--bg-base);
+}
+
 .hunt-empty {
   padding: 40px 20px;
   color: var(--text-faint);

--- a/public/views/hunt.js
+++ b/public/views/hunt.js
@@ -99,7 +99,10 @@
               </ul>
             </div>
           ` : ''}
-          <button class="hunt-start" data-bait="${esc(b.bait_id)}">Start Hunt</button>
+          <div class="hunt-card-actions">
+            <button class="hunt-start" data-bait="${esc(b.bait_id)}">Start Hunt</button>
+            ${data.is_dev ? `<button class="hunt-start hunt-start-dev" data-bait="${esc(b.bait_id)}" data-count="2" title="Dev only: force a 2-enemy spawn">+2 (dev)</button>` : ''}
+          </div>
         </div>
       </article>
     `;}).join('');
@@ -114,7 +117,7 @@
     `;
 
     body.querySelectorAll('.hunt-start').forEach(btn => {
-      btn.addEventListener('click', () => startHunt(btn.dataset.bait, btn));
+      btn.addEventListener('click', () => startHunt(btn.dataset.bait, btn, btn.dataset.count ? parseInt(btn.dataset.count, 10) : 1));
     });
     bindNav(body);
   }
@@ -130,18 +133,19 @@
     });
   }
 
-  async function startHunt(baitId, btn) {
+  async function startHunt(baitId, btn, count = 1) {
     if (starting) return;
     starting = true;
     const err = document.getElementById('hunt-error');
     if (err) err.hidden = true;
     btn.disabled = true;
+    const originalText = btn.textContent;
     btn.textContent = 'Entering…';
     try {
       const res = await fetch('/api/hunt/start', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bait_id: baitId }),
+        body: JSON.stringify({ bait_id: baitId, count }),
       });
       const json = await res.json().catch(() => ({}));
       if (!res.ok || !json.session_url) {
@@ -151,7 +155,7 @@
     } catch (e) {
       starting = false;
       btn.disabled = false;
-      btn.textContent = 'Start Hunt';
+      btn.textContent = originalText;
       if (err) { err.textContent = e.message; err.hidden = false; }
     }
   }

--- a/public/views/lore.css
+++ b/public/views/lore.css
@@ -1,0 +1,116 @@
+/* View: Lore — sidebar + detail layout, mirrors enemies.css structure */
+
+.lore-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  height: 100%;
+}
+
+.lore-sidebar {
+  width: 200px;
+  min-width: 200px;
+  background: var(--bg-surface);
+  border-right: 2px solid var(--border-soft);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.lore-sidebar h2 {
+  font-size: 0.75rem;
+  color: var(--gold);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 16px 16px 10px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.lore-list { overflow-y: auto; flex: 1; }
+
+.lore-btn {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  cursor: pointer;
+  text-align: left;
+}
+.lore-btn:hover { background: var(--bg-hover); color: var(--text-2); }
+.lore-btn.active { background: var(--bg-hover); color: var(--gold); }
+
+.lore-detail {
+  flex: 1;
+  overflow-y: auto;
+  padding: 28px 40px;
+}
+
+.lore-hint { color: var(--text-faint); font-style: italic; margin-top: 40px; text-align: center; }
+
+.lore-article {
+  max-width: 720px;
+  color: var(--text-2);
+  line-height: 1.6;
+}
+
+.lore-article h1 {
+  font-size: 1.5rem;
+  color: var(--gold);
+  margin-bottom: 18px;
+  border-bottom: 1px solid var(--border-soft);
+  padding-bottom: 10px;
+}
+
+.lore-article h2 {
+  font-size: 1.05rem;
+  color: var(--gold);
+  margin: 28px 0 10px;
+  letter-spacing: 0.02em;
+}
+
+.lore-article h3 {
+  font-size: 0.95rem;
+  color: var(--text-2);
+  margin: 22px 0 6px;
+  font-weight: 600;
+}
+
+.lore-article p {
+  margin-bottom: 12px;
+  color: var(--text-muted);
+}
+
+.lore-article ul {
+  margin: 8px 0 16px 22px;
+  color: var(--text-muted);
+}
+
+.lore-article li {
+  margin-bottom: 6px;
+}
+
+.lore-article strong {
+  color: var(--text-2);
+  font-weight: 600;
+}
+
+.lore-article em {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.lore-article hr {
+  border: none;
+  border-top: 1px solid var(--border-soft);
+  margin: 24px 0;
+}
+
+@media (max-width: 600px) {
+  .lore-sidebar { width: 140px; min-width: 140px; }
+  .lore-detail { padding: 18px 20px; }
+  .lore-article h1 { font-size: 1.3rem; }
+}

--- a/public/views/lore.css
+++ b/public/views/lore.css
@@ -109,6 +109,40 @@
   margin: 24px 0;
 }
 
+.lore-article code {
+  background: var(--bg-deep);
+  color: var(--teal-bright);
+  font-family: monospace;
+  font-size: 0.85em;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.ref-table {
+  border-collapse: collapse;
+  margin: 12px 0 16px;
+  font-size: 0.85rem;
+  border: 1px solid var(--border-soft);
+}
+.ref-table th,
+.ref-table td {
+  padding: 6px 12px;
+  border: 1px solid var(--border-soft);
+  text-align: left;
+  vertical-align: top;
+}
+.ref-table th {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  background: var(--bg-deep);
+}
+.ref-table tbody tr:hover td { background: var(--bg-hover); }
+.ref-table td { color: var(--text-muted); }
+.ref-table td strong { color: var(--text-2); }
+
 @media (max-width: 600px) {
   .lore-sidebar { width: 140px; min-width: 140px; }
   .lore-detail { padding: 18px 20px; }

--- a/public/views/lore.css
+++ b/public/views/lore.css
@@ -84,13 +84,21 @@
   color: var(--text-muted);
 }
 
-.lore-article ul {
+.lore-article ul,
+.lore-article ol {
   margin: 8px 0 16px 22px;
   color: var(--text-muted);
 }
 
 .lore-article li {
   margin-bottom: 6px;
+}
+
+.lore-article ul ul,
+.lore-article ul ol,
+.lore-article ol ul,
+.lore-article ol ol {
+  margin: 6px 0 6px 18px;
 }
 
 .lore-article strong {

--- a/public/views/lore.css
+++ b/public/views/lore.css
@@ -143,6 +143,13 @@
 .ref-table td { color: var(--text-muted); }
 .ref-table td strong { color: var(--text-2); }
 
+.ref-link {
+  color: var(--gold);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--gold-dim, var(--gold));
+}
+.ref-link:hover { color: var(--text-2); border-bottom-color: var(--text-2); }
+
 @media (max-width: 600px) {
   .lore-sidebar { width: 140px; min-width: 140px; }
   .lore-detail { padding: 18px 20px; }

--- a/public/views/lore.js
+++ b/public/views/lore.js
@@ -1,0 +1,120 @@
+// View: Lore — sidebar of sections, detail panel renders markdown body.
+(function() {
+  let sections = [];
+  let selectedTitle = null;
+
+  function esc(s) {
+    return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  // Tiny markdown -> HTML for the lore body. Handles what the lore doc uses:
+  // H2/H3 headings, **bold**, *italic*, --- rules, - bullets, blank-line paragraphs.
+  function renderMarkdown(md) {
+    const lines = md.split(/\r?\n/);
+    const out = [];
+    let inList = false;
+    let paragraph = [];
+
+    const flushParagraph = () => {
+      if (paragraph.length === 0) return;
+      const text = paragraph.join(' ').trim();
+      if (text) out.push(`<p>${formatInline(text)}</p>`);
+      paragraph = [];
+    };
+    const closeList = () => { if (inList) { out.push('</ul>'); inList = false; } };
+
+    for (const raw of lines) {
+      const line = raw.trimEnd();
+      if (/^---+$/.test(line.trim())) {
+        flushParagraph(); closeList();
+        out.push('<hr>');
+        continue;
+      }
+      const h2 = line.match(/^## (.+)$/);
+      if (h2) { flushParagraph(); closeList(); out.push(`<h2>${formatInline(h2[1])}</h2>`); continue; }
+      const h3 = line.match(/^### (.+)$/);
+      if (h3) { flushParagraph(); closeList(); out.push(`<h3>${formatInline(h3[1])}</h3>`); continue; }
+      const bullet = line.match(/^- (.+)$/);
+      if (bullet) {
+        flushParagraph();
+        if (!inList) { out.push('<ul>'); inList = true; }
+        out.push(`<li>${formatInline(bullet[1])}</li>`);
+        continue;
+      }
+      if (line.trim() === '') { flushParagraph(); closeList(); continue; }
+      paragraph.push(line);
+    }
+    flushParagraph(); closeList();
+    return out.join('\n');
+  }
+
+  function formatInline(s) {
+    return esc(s)
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, '$1<em>$2</em>');
+  }
+
+  function slugify(title) {
+    return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  }
+
+  async function mount(root) {
+    setLayoutTitle('Lore');
+    root.innerHTML = `
+      <div class="lore-body">
+        <aside class="lore-sidebar">
+          <h2>Lore</h2>
+          <div class="lore-list" id="lore-list"></div>
+        </aside>
+        <main class="lore-detail" id="lore-detail">
+          <p class="lore-hint">Select a section.</p>
+        </main>
+      </div>
+    `;
+
+    const res = await fetch('/api/info/lore');
+    if (!res.ok) {
+      document.getElementById('lore-detail').innerHTML = `<p class="lore-hint">Could not load lore.</p>`;
+      return;
+    }
+    const data = await res.json();
+    sections = data.sections;
+
+    const list = document.getElementById('lore-list');
+    list.innerHTML = '';
+    for (const s of sections) {
+      const btn = document.createElement('button');
+      btn.className = 'lore-btn';
+      btn.dataset.slug = slugify(s.title);
+      btn.textContent = s.title;
+      btn.onclick = () => select(s.title);
+      list.appendChild(btn);
+    }
+
+    if (sections.length > 0) select(sections[0].title);
+  }
+
+  function select(title) {
+    const sec = sections.find(s => s.title === title);
+    if (!sec) return;
+    selectedTitle = title;
+    const slug = slugify(title);
+    document.querySelectorAll('.lore-btn').forEach(b => b.classList.toggle('active', b.dataset.slug === slug));
+
+    document.getElementById('lore-detail').innerHTML = `
+      <article class="lore-article">
+        <h1>${esc(sec.title)}</h1>
+        ${renderMarkdown(sec.body)}
+      </article>
+    `;
+    document.getElementById('lore-detail').scrollTop = 0;
+  }
+
+  function unmount() {
+    sections = [];
+    selectedTitle = null;
+  }
+
+  window.Views = window.Views ?? {};
+  window.Views.lore = { mount, unmount };
+})();

--- a/public/views/reference.js
+++ b/public/views/reference.js
@@ -19,9 +19,11 @@
   function renderMarkdown(md) {
     const lines = md.split(/\r?\n/);
     const out = [];
-    let inList = false;
+    // Stack of open lists: each entry = { tag: 'ul'|'ol', indent: number }.
+    // Indent-based nesting: 0 spaces = top level, 2+ spaces = sub-list.
+    const listStack = [];
     let paragraph = [];
-    let tableRows = null;          // null | array of cell-arrays
+    let tableRows = null;
     let tableHeader = null;
 
     const flushParagraph = () => {
@@ -30,7 +32,14 @@
       if (text) out.push(`<p>${formatInline(text)}</p>`);
       paragraph = [];
     };
-    const closeList = () => { if (inList) { out.push('</ul>'); inList = false; } };
+    const closeAllLists = () => {
+      while (listStack.length) { out.push(`</${listStack.pop().tag}>`); }
+    };
+    const closeListsDeeperThan = (indent) => {
+      while (listStack.length && listStack[listStack.length - 1].indent > indent) {
+        out.push(`</${listStack.pop().tag}>`);
+      }
+    };
     const closeTable = () => {
       if (!tableRows) return;
       const head = tableHeader ? `<thead><tr>${tableHeader.map(h => `<th>${formatInline(h)}</th>`).join('')}</tr></thead>` : '';
@@ -40,40 +49,57 @@
     };
 
     for (const raw of lines) {
-      const line = raw.trimEnd();
+      const line = raw.replace(/\s+$/, '');
       const tableRow = line.match(/^\|(.+)\|$/);
       const tableSep = line.match(/^\|[\s\-:|]+\|$/);
 
       if (tableRow && !tableSep) {
-        flushParagraph(); closeList();
+        flushParagraph(); closeAllLists();
         const cells = tableRow[1].split('|').map(c => c.trim());
         if (!tableRows) { tableHeader = cells; tableRows = []; }
         else { tableRows.push(cells); }
         continue;
       }
-      if (tableSep) continue; // separator row between header + body — ignored
+      if (tableSep) continue;
       if (tableRows) closeTable();
 
       if (/^---+$/.test(line.trim())) {
-        flushParagraph(); closeList();
+        flushParagraph(); closeAllLists();
         out.push('<hr>');
         continue;
       }
       const h2 = line.match(/^## (.+)$/);
-      if (h2) { flushParagraph(); closeList(); out.push(`<h2>${formatInline(h2[1])}</h2>`); continue; }
+      if (h2) { flushParagraph(); closeAllLists(); out.push(`<h2>${formatInline(h2[1])}</h2>`); continue; }
       const h3 = line.match(/^### (.+)$/);
-      if (h3) { flushParagraph(); closeList(); out.push(`<h3>${formatInline(h3[1])}</h3>`); continue; }
-      const bullet = line.match(/^- (.+)$/);
-      if (bullet) {
+      if (h3) { flushParagraph(); closeAllLists(); out.push(`<h3>${formatInline(h3[1])}</h3>`); continue; }
+
+      // Bullets (`- text`) and numbered (`1. text`), with optional indent for nesting
+      const bullet = line.match(/^(\s*)- (.+)$/);
+      const numbered = line.match(/^(\s*)\d+\. (.+)$/);
+      const listItem = bullet || numbered;
+      if (listItem) {
         flushParagraph();
-        if (!inList) { out.push('<ul>'); inList = true; }
-        out.push(`<li>${formatInline(bullet[1])}</li>`);
+        const indent = listItem[1].length;
+        const tag = bullet ? 'ul' : 'ol';
+        closeListsDeeperThan(indent);
+        const top = listStack[listStack.length - 1];
+        if (!top || top.indent < indent) {
+          out.push(`<${tag}>`);
+          listStack.push({ tag, indent });
+        } else if (top.tag !== tag) {
+          // Same indent but different list type — close and reopen.
+          out.push(`</${listStack.pop().tag}>`);
+          out.push(`<${tag}>`);
+          listStack.push({ tag, indent });
+        }
+        out.push(`<li>${formatInline(listItem[2])}</li>`);
         continue;
       }
-      if (line.trim() === '') { flushParagraph(); closeList(); continue; }
+
+      if (line.trim() === '') { flushParagraph(); closeAllLists(); continue; }
       paragraph.push(line);
     }
-    flushParagraph(); closeList(); closeTable();
+    flushParagraph(); closeAllLists(); closeTable();
     return out.join('\n');
   }
 

--- a/public/views/reference.js
+++ b/public/views/reference.js
@@ -11,6 +11,7 @@
   function formatInline(s) {
     return esc(s)
       .replace(/`([^`]+)`/g, '<code>$1</code>')
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="ref-link">$1</a>')
       .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
       .replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, '$1<em>$2</em>');
   }

--- a/public/views/reference.js
+++ b/public/views/reference.js
@@ -1,0 +1,140 @@
+// View: Reference — game terms + pages overview. Mirrors lore.js with the
+// reference endpoint + a tiny inline-table renderer in the markdown step.
+(function() {
+  let sections = [];
+  let selectedTitle = null;
+
+  function esc(s) {
+    return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function formatInline(s) {
+    return esc(s)
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, '$1<em>$2</em>');
+  }
+
+  function renderMarkdown(md) {
+    const lines = md.split(/\r?\n/);
+    const out = [];
+    let inList = false;
+    let paragraph = [];
+    let tableRows = null;          // null | array of cell-arrays
+    let tableHeader = null;
+
+    const flushParagraph = () => {
+      if (paragraph.length === 0) return;
+      const text = paragraph.join(' ').trim();
+      if (text) out.push(`<p>${formatInline(text)}</p>`);
+      paragraph = [];
+    };
+    const closeList = () => { if (inList) { out.push('</ul>'); inList = false; } };
+    const closeTable = () => {
+      if (!tableRows) return;
+      const head = tableHeader ? `<thead><tr>${tableHeader.map(h => `<th>${formatInline(h)}</th>`).join('')}</tr></thead>` : '';
+      const body = tableRows.map(r => `<tr>${r.map(c => `<td>${formatInline(c)}</td>`).join('')}</tr>`).join('');
+      out.push(`<table class="ref-table">${head}<tbody>${body}</tbody></table>`);
+      tableRows = null; tableHeader = null;
+    };
+
+    for (const raw of lines) {
+      const line = raw.trimEnd();
+      const tableRow = line.match(/^\|(.+)\|$/);
+      const tableSep = line.match(/^\|[\s\-:|]+\|$/);
+
+      if (tableRow && !tableSep) {
+        flushParagraph(); closeList();
+        const cells = tableRow[1].split('|').map(c => c.trim());
+        if (!tableRows) { tableHeader = cells; tableRows = []; }
+        else { tableRows.push(cells); }
+        continue;
+      }
+      if (tableSep) continue; // separator row between header + body — ignored
+      if (tableRows) closeTable();
+
+      if (/^---+$/.test(line.trim())) {
+        flushParagraph(); closeList();
+        out.push('<hr>');
+        continue;
+      }
+      const h2 = line.match(/^## (.+)$/);
+      if (h2) { flushParagraph(); closeList(); out.push(`<h2>${formatInline(h2[1])}</h2>`); continue; }
+      const h3 = line.match(/^### (.+)$/);
+      if (h3) { flushParagraph(); closeList(); out.push(`<h3>${formatInline(h3[1])}</h3>`); continue; }
+      const bullet = line.match(/^- (.+)$/);
+      if (bullet) {
+        flushParagraph();
+        if (!inList) { out.push('<ul>'); inList = true; }
+        out.push(`<li>${formatInline(bullet[1])}</li>`);
+        continue;
+      }
+      if (line.trim() === '') { flushParagraph(); closeList(); continue; }
+      paragraph.push(line);
+    }
+    flushParagraph(); closeList(); closeTable();
+    return out.join('\n');
+  }
+
+  function slugify(title) {
+    return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  }
+
+  async function mount(root) {
+    setLayoutTitle('Reference');
+    root.innerHTML = `
+      <div class="lore-body">
+        <aside class="lore-sidebar">
+          <h2>Reference</h2>
+          <div class="lore-list" id="ref-list"></div>
+        </aside>
+        <main class="lore-detail" id="ref-detail">
+          <p class="lore-hint">Select a section.</p>
+        </main>
+      </div>
+    `;
+
+    const res = await fetch('/api/info/reference');
+    if (!res.ok) {
+      document.getElementById('ref-detail').innerHTML = `<p class="lore-hint">Could not load reference.</p>`;
+      return;
+    }
+    const data = await res.json();
+    sections = data.sections;
+
+    const list = document.getElementById('ref-list');
+    list.innerHTML = '';
+    for (const s of sections) {
+      const btn = document.createElement('button');
+      btn.className = 'lore-btn';
+      btn.dataset.slug = slugify(s.title);
+      btn.textContent = s.title;
+      btn.onclick = () => select(s.title);
+      list.appendChild(btn);
+    }
+    if (sections.length > 0) select(sections[0].title);
+  }
+
+  function select(title) {
+    const sec = sections.find(s => s.title === title);
+    if (!sec) return;
+    selectedTitle = title;
+    const slug = slugify(title);
+    document.querySelectorAll('.lore-btn').forEach(b => b.classList.toggle('active', b.dataset.slug === slug));
+    document.getElementById('ref-detail').innerHTML = `
+      <article class="lore-article">
+        <h1>${esc(sec.title)}</h1>
+        ${renderMarkdown(sec.body)}
+      </article>
+    `;
+    document.getElementById('ref-detail').scrollTop = 0;
+  }
+
+  function unmount() {
+    sections = [];
+    selectedTitle = null;
+  }
+
+  window.Views = window.Views ?? {};
+  window.Views.reference = { mount, unmount };
+})();

--- a/public/views/reference.js
+++ b/public/views/reference.js
@@ -122,13 +122,25 @@
     selectedTitle = title;
     const slug = slugify(title);
     document.querySelectorAll('.lore-btn').forEach(b => b.classList.toggle('active', b.dataset.slug === slug));
-    document.getElementById('ref-detail').innerHTML = `
+    const detail = document.getElementById('ref-detail');
+    detail.innerHTML = `
       <article class="lore-article">
         <h1>${esc(sec.title)}</h1>
         ${renderMarkdown(sec.body)}
       </article>
     `;
-    document.getElementById('ref-detail').scrollTop = 0;
+    detail.scrollTop = 0;
+
+    // Intercept intra-page anchor links (#section-slug) and route them to
+    // select() so they switch sections instead of doing a full navigation.
+    detail.querySelectorAll('a[href^="#"]').forEach(a => {
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        const slug = a.getAttribute('href').slice(1);
+        const target = sections.find(s => slugify(s.title) === slug);
+        if (target) select(target.title);
+      });
+    });
   }
 
   function unmount() {

--- a/src/combat/combat_session.ts
+++ b/src/combat/combat_session.ts
@@ -3,6 +3,7 @@ import { CombatIntent } from './intent.js';
 import Weapon from '../weapon/weapon.js';
 import { CombatantState } from './combatant_state.js';
 import { PatternEntry } from '../infrastructure/pattern.js';
+import { assignInitiative } from './initiative.js';
 
 export interface ActionInfo {
   label: string;
@@ -45,6 +46,9 @@ export interface Combatant {
   isAI: boolean;
   teamId: string;
   weaponInfo: WeaponInfo;
+  weight: number;        // weapon weight; drives initiative roll
+  initiative: number;    // rolled at session start: (1..100) - weight. Higher acts first.
+  initiativeRank: number;// final 0-based rank across all combatants after tiebreaks; lower = sooner
   sprite?: string;
   status?: CombatantStatus;
 }
@@ -88,6 +92,7 @@ export class CombatSession {
     this.id = id;
     this.board = new Board(boardConfig);
     this.teams = teams;
+    assignInitiative(this.combatants);
   }
 
   get combatants(): Combatant[] {

--- a/src/combat/combat_session.ts
+++ b/src/combat/combat_session.ts
@@ -87,12 +87,17 @@ export class CombatSession {
   turn: number = 0;
   phase: SessionPhase = 'waiting';
   telegraphs: Record<string, string> = {};
+  // Initiative-roll log captured at session start; the first round's
+  // resolveIntents drains this into its log so players see the rolls before
+  // any combat output. Cleared after first drain so subsequent rounds don't
+  // re-emit it.
+  pendingPrefaceLog: string[] = [];
 
   constructor(id: string, boardConfig: BoardConfig, teams: Team[]) {
     this.id = id;
     this.board = new Board(boardConfig);
     this.teams = teams;
-    assignInitiative(this.combatants);
+    this.pendingPrefaceLog = assignInitiative(this.combatants);
   }
 
   get combatants(): Combatant[] {

--- a/src/combat/combat_session.ts
+++ b/src/combat/combat_session.ts
@@ -87,17 +87,16 @@ export class CombatSession {
   turn: number = 0;
   phase: SessionPhase = 'waiting';
   telegraphs: Record<string, string> = {};
-  // Initiative-roll log captured at session start; the first round's
-  // resolveIntents drains this into its log so players see the rolls before
-  // any combat output. Cleared after first drain so subsequent rounds don't
-  // re-emit it.
-  pendingPrefaceLog: string[] = [];
+  // Initiative-roll log captured at session start. Emitted to clients on
+  // every join_session so refreshers / late-joiners see it too, and
+  // persisted as a synthetic "turn 0" entry in the battle log.
+  initiativeLog: string[] = [];
 
   constructor(id: string, boardConfig: BoardConfig, teams: Team[]) {
     this.id = id;
     this.board = new Board(boardConfig);
     this.teams = teams;
-    this.pendingPrefaceLog = assignInitiative(this.combatants);
+    this.initiativeLog = assignInitiative(this.combatants);
   }
 
   get combatants(): Combatant[] {

--- a/src/combat/enemy_loader.ts
+++ b/src/combat/enemy_loader.ts
@@ -85,11 +85,18 @@ export function loadEnemy(file: string, options: {
     initiativeRank: 0,  // set by assignInitiative in CombatSession constructor
   };
 
+  // Start at a random index in the pattern so two of the same enemy on the
+  // same board don't telegraph identical actions every turn — adds variety
+  // and makes second-enemy spawns feel different from the first.
+  const startIndex = pattern.field.length > 0
+    ? Math.floor(Math.random() * pattern.field.length)
+    : 0;
+
   const meta: CombatantMeta = {
     weapon,
     state,
     pattern: pattern.field,
-    patternIndex: 0,
+    patternIndex: startIndex,
   };
 
   const lootTable: LootTable = {

--- a/src/combat/enemy_loader.ts
+++ b/src/combat/enemy_loader.ts
@@ -80,6 +80,9 @@ export function loadEnemy(file: string, options: {
     isAI: true,
     teamId: options.teamId,
     weaponInfo,
+    weight: weapon.weight,
+    initiative: 0,      // set by assignInitiative in CombatSession constructor
+    initiativeRank: 0,  // set by assignInitiative in CombatSession constructor
   };
 
   const meta: CombatantMeta = {

--- a/src/combat/initiative.ts
+++ b/src/combat/initiative.ts
@@ -14,7 +14,9 @@ export function rollInitiativeScore(weight: number): number {
 }
 
 // Mutates each combatant, setting .initiative and .initiativeRank.
-export function assignInitiative(combatants: Combatant[]): void {
+// Returns log lines describing the rolls + final order, suitable for
+// prepending to the first round of the combat log.
+export function assignInitiative(combatants: Combatant[]): string[] {
   for (const c of combatants) {
     c.initiative = rollInitiativeScore(c.weight);
   }
@@ -26,4 +28,11 @@ export function assignInitiative(combatants: Combatant[]): void {
     return Math.random() < 0.5 ? -1 : 1;
   });
   sorted.forEach((c, i) => { c.initiativeRank = i; });
+
+  const log: string[] = ['⚔ Rolling initiative…'];
+  for (const c of sorted) {
+    log.push(`  ${c.name}: rolled ${c.initiative} (1–100 minus weight ${c.weight})`);
+  }
+  log.push(`Order: ${sorted.map(c => c.name).join(' → ')}`);
+  return log;
 }

--- a/src/combat/initiative.ts
+++ b/src/combat/initiative.ts
@@ -1,0 +1,29 @@
+import { Combatant } from './combat_session.js';
+
+// DnD-style initiative. Each combatant rolls 1..100 minus their weight; higher
+// goes first. Ties:
+//   1. Player beats NPC.
+//   2. Otherwise, coin flip.
+// Roll once per battle (current rule) and assign deterministic ranks 0..N-1.
+//
+// Effect of weight: heavier weapons go later. Weight 0 = no penalty (current
+// default for every weapon and enemy until per-weapon weights are tuned).
+
+export function rollInitiativeScore(weight: number): number {
+  return Math.floor(Math.random() * 100) + 1 - weight;
+}
+
+// Mutates each combatant, setting .initiative and .initiativeRank.
+export function assignInitiative(combatants: Combatant[]): void {
+  for (const c of combatants) {
+    c.initiative = rollInitiativeScore(c.weight);
+  }
+  const sorted = [...combatants].sort((a, b) => {
+    if (a.initiative !== b.initiative) return b.initiative - a.initiative;
+    // Tie: player beats NPC. Player has isAI=false.
+    if (a.isAI !== b.isAI) return a.isAI ? 1 : -1;
+    // Still tied (both player or both NPC). Coin flip.
+    return Math.random() < 0.5 ? -1 : 1;
+  });
+  sorted.forEach((c, i) => { c.initiativeRank = i; });
+}

--- a/src/combat/initiative.ts
+++ b/src/combat/initiative.ts
@@ -14,8 +14,7 @@ export function rollInitiativeScore(weight: number): number {
 }
 
 // Mutates each combatant, setting .initiative and .initiativeRank.
-// Returns log lines describing the rolls + final order, suitable for
-// prepending to the first round of the combat log.
+// Returns log lines describing the rolls + final order.
 export function assignInitiative(combatants: Combatant[]): string[] {
   for (const c of combatants) {
     c.initiative = rollInitiativeScore(c.weight);
@@ -29,10 +28,6 @@ export function assignInitiative(combatants: Combatant[]): string[] {
   });
   sorted.forEach((c, i) => { c.initiativeRank = i; });
 
-  const log: string[] = ['⚔ Rolling initiative…'];
-  for (const c of sorted) {
-    log.push(`  ${c.name}: rolled ${c.initiative} (1–100 minus weight ${c.weight})`);
-  }
-  log.push(`Order: ${sorted.map(c => c.name).join(' → ')}`);
-  return log;
+  const parts = sorted.map(c => `${c.name} ${c.initiative}`);
+  return [`Initiative — ${parts.join(', ')}`];
 }

--- a/src/combat/initiative.ts
+++ b/src/combat/initiative.ts
@@ -28,6 +28,9 @@ export function assignInitiative(combatants: Combatant[]): string[] {
   });
   sorted.forEach((c, i) => { c.initiativeRank = i; });
 
-  const parts = sorted.map(c => `${c.name} ${c.initiative}`);
-  return [`Initiative — ${parts.join(', ')}`];
+  const lines = ['Initiative:'];
+  sorted.forEach((c, i) => {
+    lines.push(`  ${i + 1}. ${c.name} — ${c.initiative}`);
+  });
+  return lines;
 }

--- a/src/combat/resolution.ts
+++ b/src/combat/resolution.ts
@@ -24,14 +24,6 @@ export function resolveIntents(
 ): ResolutionResult {
   const log: string[] = [];
 
-  // Drain any pending preface log (initiative rolls on first round, etc.)
-  // exactly once, so it appears at the top of the first round's output and
-  // gets persisted with that round into the battle log table.
-  if (session.pendingPrefaceLog.length > 0) {
-    log.push(...session.pendingPrefaceLog);
-    session.pendingPrefaceLog = [];
-  }
-
   const snapshot = [...session.combatants];
   const cName = (id: string) => snapshot.find(c => c.id === id)?.name ?? id;
 

--- a/src/combat/resolution.ts
+++ b/src/combat/resolution.ts
@@ -41,7 +41,7 @@ export function resolveIntents(
 
   const blocked = new Set<string>();
 
-  for (const [, claimants] of byDest) {
+  for (const [destKey, claimants] of byDest) {
     if (claimants.length === 1) continue;
     const bestPriority = Math.min(...claimants.map(movePriority));
     const winners = claimants.filter(id => movePriority(id) === bestPriority);
@@ -49,7 +49,7 @@ export function resolveIntents(
       for (const id of claimants) {
         if (id !== winners[0]) {
           blocked.add(id);
-          log.push(`${cName(id)} yields to ${cName(winners[0])}.`);
+          log.push(`${cName(id)}'s path to (${destKey}) blocked by ${cName(winners[0])}.`);
         }
       }
     } else {
@@ -78,10 +78,19 @@ export function resolveIntents(
     }
   }
 
+  // Re-route blocked AI combatants. We don't store the BFS path of their
+  // intended move, so we approximate "stop on the path" by picking the
+  // reachable tile that gets the combatant closest to the ORIGINAL
+  // destination (the tile they wanted but lost). Strict-less would force
+  // them to stay put any time they couldn't get strictly closer; <= lets
+  // them step toward the destination even when the chebyshev distance is
+  // tied (which is the case for the last tile before a blocked dest).
   for (const [id] of intents) {
     if (!blocked.has(id)) continue;
     const c = snapshot.find(c => c.id === id);
     if (!c?.isAI) continue;
+    const originalDest = intents.get(id)?.moveTo;
+    if (!originalDest) continue;
 
     const allOccupied = new Set<string>([
       ...snapshot.filter(o => o.id !== id).map(o => `${o.pos.x},${o.pos.y}`),
@@ -90,17 +99,11 @@ export function resolveIntents(
 
     const reachable = reachableTiles(c.pos, c.movementRange, session.board, allOccupied);
 
-    const enemies = snapshot.filter(e => e.teamId !== c.teamId);
-    if (enemies.length === 0) continue;
-    const target = enemies.reduce((a, b) =>
-      chebyshevDist(c.pos, a.pos) <= chebyshevDist(c.pos, b.pos) ? a : b
-    );
-
-    let bestDist = chebyshevDist(c.pos, target.pos);
+    let bestDist = chebyshevDist(c.pos, originalDest);
     let bestPos: { x: number; y: number } | null = null;
     for (const pos of reachable.values()) {
-      const d = chebyshevDist(pos, target.pos);
-      if (d < bestDist) { bestDist = d; bestPos = pos; }
+      const d = chebyshevDist(pos, originalDest);
+      if (d <= bestDist) { bestDist = d; bestPos = pos; }
     }
 
     if (bestPos) {

--- a/src/combat/resolution.ts
+++ b/src/combat/resolution.ts
@@ -24,6 +24,14 @@ export function resolveIntents(
 ): ResolutionResult {
   const log: string[] = [];
 
+  // Drain any pending preface log (initiative rolls on first round, etc.)
+  // exactly once, so it appears at the top of the first round's output and
+  // gets persisted with that round into the battle log table.
+  if (session.pendingPrefaceLog.length > 0) {
+    log.push(...session.pendingPrefaceLog);
+    session.pendingPrefaceLog = [];
+  }
+
   const snapshot = [...session.combatants];
   const cName = (id: string) => snapshot.find(c => c.id === id)?.name ?? id;
 

--- a/src/combat/resolution.ts
+++ b/src/combat/resolution.ts
@@ -28,7 +28,10 @@ export function resolveIntents(
   const cName = (id: string) => snapshot.find(c => c.id === id)?.name ?? id;
 
   // --- Move phase ---
-  const movePriority = (id: string) => (snapshot.find(c => c.id === id)?.isAI ? 2 : 1);
+  // Use initiative rank to resolve which combatant wins a contested tile.
+  // Initiative ranks are unique (0..N-1), so winners.length is always 1 —
+  // no genuine ties are possible.
+  const movePriority = (id: string) => snapshot.find(c => c.id === id)?.initiativeRank ?? Infinity;
 
   const byDest = new Map<string, string[]>();
   for (const [id, intent] of intents) {
@@ -43,18 +46,13 @@ export function resolveIntents(
 
   for (const [destKey, claimants] of byDest) {
     if (claimants.length === 1) continue;
-    const bestPriority = Math.min(...claimants.map(movePriority));
-    const winners = claimants.filter(id => movePriority(id) === bestPriority);
-    if (winners.length === 1) {
-      for (const id of claimants) {
-        if (id !== winners[0]) {
-          blocked.add(id);
-          log.push(`${cName(id)}'s path to (${destKey}) blocked by ${cName(winners[0])}.`);
-        }
+    const sortedByPriority = [...claimants].sort((a, b) => movePriority(a) - movePriority(b));
+    const winner = sortedByPriority[0];
+    for (const id of claimants) {
+      if (id !== winner) {
+        blocked.add(id);
+        log.push(`${cName(id)}'s path to (${destKey}) blocked by ${cName(winner)}.`);
       }
-    } else {
-      for (const id of claimants) blocked.add(id);
-      log.push(`${winners.map(cName).join(' and ')} tie for the same tile — neither moves.`);
     }
   }
 

--- a/src/combat/resolution.ts
+++ b/src/combat/resolution.ts
@@ -245,11 +245,12 @@ export function resolveIntents(
     return null;
   };
 
-  // Action sub-phases: defend → attack → special. Player first within each.
-  // Snapshot the actor order ONCE — combatants get removed mid-phase by reapAndCheck.
-  const playerIds = snapshot.filter(c => !c.isAI).map(c => c.id);
-  const aiIds     = snapshot.filter(c =>  c.isAI).map(c => c.id);
-  const orderedIds = [...playerIds, ...aiIds];
+  // Action sub-phases: defend → attack → special. Initiative order within each
+  // (lower rank = sooner). Snapshot the actor order ONCE — combatants get removed
+  // mid-phase by reapAndCheck and we don't want order to shift.
+  const orderedIds = [...snapshot]
+    .sort((a, b) => a.initiativeRank - b.initiativeRank)
+    .map(c => c.id);
 
   const subPhases: Array<'defend' | 'attack' | 'special'> = ['defend', 'attack', 'special'];
 
@@ -275,11 +276,11 @@ export function resolveIntents(
     return { log, winner: earlyWinner };
   }
 
-  // --- End of round: tick DOT/status sequentially (enemies first), checking
-  // for death after each tick. First combatant to reach 0 ends the fight for
-  // their team; the other side's DOT never gets to tick.
+  // --- End of round: tick DOT/status sequentially in initiative order,
+  // checking for death after each tick. First combatant to reach 0 ends the
+  // fight for their team; later combatants' DOTs never tick.
   let winner: string | null = null;
-  const dotOrder = [...session.combatants].sort((a, b) => Number(b.isAI) - Number(a.isAI));
+  const dotOrder = [...session.combatants].sort((a, b) => a.initiativeRank - b.initiativeRank);
   for (const c of dotOrder) {
     const meta = session.meta.get(c.id);
     if (!meta) continue;

--- a/src/economy/shop_service.ts
+++ b/src/economy/shop_service.ts
@@ -43,7 +43,9 @@ async function getOrCreateState(shopKey: string, item: ShopItemListing) {
 async function maybeTickDaily(shopKey: string, item: ShopItemListing, state: Awaited<ReturnType<typeof getOrCreateState>>) {
   if (Date.now() - state.last_tick.getTime() < TICK_INTERVAL_MS) return state;
 
-  const newRecentVolume = Math.floor(state.recent_volume * RECENT_VOLUME_DECAY);
+  // recent_volume is BigInt in the schema (to avoid INT4 overflow); coerce to
+  // Number for the decay math. Realistic values stay far below MAX_SAFE_INTEGER.
+  const newRecentVolume = Math.floor(Number(state.recent_volume) * RECENT_VOLUME_DECAY);
   const r      = currentR(item, newRecentVolume);
   const newX   = logisticStep(state.x, r);
   // Daily tick handles price/restock only. Destock is now on its own hourly
@@ -67,7 +69,7 @@ async function maybeTickDaily(shopKey: string, item: ShopItemListing, state: Awa
     });
   }
 
-  return { ...state, x: newX, stock: newStock, recent_volume: newRecentVolume, last_tick: new Date() };
+  return { ...state, x: newX, stock: newStock, recent_volume: BigInt(newRecentVolume), last_tick: new Date() };
 }
 
 async function maybeHourlyDestock(shopKey: string, item: ShopItemListing, state: Awaited<ReturnType<typeof getOrCreateState>>) {
@@ -149,7 +151,7 @@ async function applyTransactionShock(shopKey: string, item: ShopItemListing, qua
     where: { shop_id_item_id: { shop_id: shopKey, item_id: item.id } },
   });
 
-  const r        = currentR(item, state.recent_volume);
+  const r        = currentR(item, Number(state.recent_volume));
   const direction = isBuy ? 1 : -1;
   const shockMag  = Math.min(quantity / item.transaction_threshold, 3) * 0.1;
   const shockedX  = clamp(state.x + direction * shockMag, 0, 1);

--- a/src/economy/shop_service.ts
+++ b/src/economy/shop_service.ts
@@ -6,10 +6,16 @@ import { loadShop } from './shop_loader.js';
 import { clamp, currentR, logisticStep, xToMultiplier, effectiveMultiplier } from './shop_math.js';
 import { ITEMS } from './items.js';
 
-const TICK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const TICK_INTERVAL_MS    = 24 * 60 * 60 * 1000;
+const DESTOCK_INTERVAL_MS = 60 * 60 * 1000;  // hourly overflow flush, decoupled from daily price tick
 const RECENT_VOLUME_DECAY = 0.7; // half-life ~2 days; ~8% remains after 7 days
-const DESTOCK_THRESHOLD   = 0.75; // when stock >= this fraction of cap, tick dumps instead of restocks
+const DESTOCK_THRESHOLD   = 0.75; // when stock >= this fraction of cap, hourly tick dumps stock
 const DESTOCK_MULTIPLIER  = 6;    // dump 6× the rolled Restock_Field value — keep stock flowing so players can always sell
+
+// In-memory gate so the hourly destock doesn't fire more than once per hour per
+// item. Lost on server restart — that's fine, worst case the next hourly walk
+// catches up on anything that's overstocked.
+const lastDestockAt = new Map<string, number>();
 
 export interface PricedItem extends ShopItemListing {
   buy?:          number;
@@ -40,13 +46,12 @@ async function maybeTickDaily(shopKey: string, item: ShopItemListing, state: Awa
   const newRecentVolume = Math.floor(state.recent_volume * RECENT_VOLUME_DECAY);
   const r      = currentR(item, newRecentVolume);
   const newX   = logisticStep(state.x, r);
-  // Same Restock_Field roll runs every tick. When stock is at or above 75% of
-  // cap the shop liquidates instead of restocking — dumps 2× the rolled value.
-  // Without this items like venison sit at stock_max forever and nobody can
-  // sell more (soft-lock).
+  // Daily tick handles price/restock only. Destock is now on its own hourly
+  // clock (see maybeHourlyDestock) so overstocked items don't sit pinned at
+  // cap for up to 24 hours waiting for the next price tick.
   const roll = rollField(item.restock_field);
   const overstocked = item.stock_max > 0 && state.stock >= item.stock_max * DESTOCK_THRESHOLD;
-  const stockDelta = overstocked ? -roll * DESTOCK_MULTIPLIER : roll;
+  const stockDelta = overstocked ? 0 : roll;
   const newStock = Math.max(0, Math.min(state.stock + stockDelta, item.stock_max));
 
   // Optimistic lock — only one concurrent request runs the tick
@@ -65,6 +70,25 @@ async function maybeTickDaily(shopKey: string, item: ShopItemListing, state: Awa
   return { ...state, x: newX, stock: newStock, recent_volume: newRecentVolume, last_tick: new Date() };
 }
 
+async function maybeHourlyDestock(shopKey: string, item: ShopItemListing, state: Awaited<ReturnType<typeof getOrCreateState>>) {
+  if (item.stock_max <= 0) return state;
+  if (state.stock < item.stock_max * DESTOCK_THRESHOLD) return state;
+
+  const key = `${shopKey}:${item.id}`;
+  const last = lastDestockAt.get(key) ?? 0;
+  if (Date.now() - last < DESTOCK_INTERVAL_MS) return state;
+
+  const roll = rollField(item.restock_field);
+  const newStock = Math.max(0, state.stock - roll * DESTOCK_MULTIPLIER);
+
+  await prisma.shopItemState.update({
+    where: { shop_id_item_id: { shop_id: shopKey, item_id: item.id } },
+    data:  { stock: newStock },
+  });
+  lastDestockAt.set(key, Date.now());
+  return { ...state, stock: newStock };
+}
+
 
 // Walk every shop yaml in shopDir, find any items whose last_tick is older
 // than TICK_INTERVAL_MS, run maybeTickDaily on each. Called on a timer from
@@ -81,10 +105,14 @@ export async function tickAllDue(shopDir: string): Promise<number> {
     for (const item of config.items) {
       try {
         let state = await getOrCreateState(shopKey, item);
-        if (Date.now() - state.last_tick.getTime() < TICK_INTERVAL_MS) continue;
-        const before = state.last_tick;
-        state = await maybeTickDaily(shopKey, item, state);
-        if (state.last_tick.getTime() !== before.getTime()) ticked++;
+        const beforeStock = state.stock;
+        state = await maybeHourlyDestock(shopKey, item, state);
+        if (Date.now() - state.last_tick.getTime() >= TICK_INTERVAL_MS) {
+          const before = state.last_tick;
+          state = await maybeTickDaily(shopKey, item, state);
+          if (state.last_tick.getTime() !== before.getTime()) ticked++;
+        }
+        if (state.stock !== beforeStock) ticked++;
       } catch (err) {
         console.error(`tickAllDue: ${shopKey}/${item.id} failed`, err);
       }
@@ -98,6 +126,7 @@ export async function getPrices(shopKey: string, config: ShopConfig): Promise<Pr
 
   for (const item of config.items) {
     let state = await getOrCreateState(shopKey, item);
+    state = await maybeHourlyDestock(shopKey, item, state);
     state = await maybeTickDaily(shopKey, item, state);
 
     const mult = effectiveMultiplier(item, state.x, state.stock);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -53,7 +53,7 @@ const httpServer = createServer(app);
 const io = new Server(httpServer);
 
 const sessions = new Map<string, CombatSession>();
-const sessionMeta = new Map<string, { discordUserId: string; isTutorial: boolean; lootTable: LootTable; enemyName: string; startedAt: Date; rounds: { turn: number; log: string[] }[] }>();
+const sessionMeta = new Map<string, { discordUserId: string; isTutorial: boolean; lootTables: LootTable[]; enemyName: string; startedAt: Date; rounds: { turn: number; log: string[] }[] }>();
 const charRepo = new CharacterRepository();
 const VALID_NATIONALITIES = ['Chae', 'Ketulvu'] as const;
 type Nationality = typeof VALID_NATIONALITIES[number];
@@ -301,7 +301,47 @@ function randomHuntObstacles(): { pos: { x: number; y: number }; state: 'intact'
   return [];
 }
 
-function createSession(sessionId: string, enemyKey: EnemyKey | 'tutorial_swallow', playerSprite?: string, playerName = 'Hero', weaponKey = 'branch', isTutorial = false, weaponUpgrades: unknown = null): { session: CombatSession; lootTable: LootTable; enemyName: string } {
+// Runs RewardService.grant once per defeated enemy (one entry in lootTables
+// per enemy in the battle), and merges the results into a single RewardResult
+// so the existing summary/UI logic doesn't have to know about multi-enemy.
+async function grantAllLoot(
+  discordId: string,
+  characterId: string,
+  lootTables: LootTable[],
+  enemyName: string,
+): Promise<{ currency: number; items: Array<{ name: string; quantity: number }>; summary: string }> {
+  const service = new RewardService();
+  let totalCurrency = 0;
+  const mergedItems = new Map<string, number>(); // name → quantity
+  for (const table of lootTables) {
+    const r = await service.grant(discordId, characterId, table, enemyName);
+    totalCurrency += r.currency;
+    for (const i of r.items) {
+      mergedItems.set(i.name, (mergedItems.get(i.name) ?? 0) + i.quantity);
+    }
+  }
+  const items = [...mergedItems.entries()].map(([name, quantity]) => ({ name, quantity }));
+  const lines = [
+    ...(totalCurrency > 0 ? [`+${totalCurrency} Korel`] : []),
+    ...items.map(i => `+${i.quantity}x ${i.name}`),
+  ];
+  return {
+    currency: totalCurrency,
+    items,
+    summary: lines.length > 0 ? lines.join('\n') : 'No drops.',
+  };
+}
+
+function createSession(
+  sessionId: string,
+  enemyKey: EnemyKey | 'tutorial_swallow',
+  playerSprite?: string,
+  playerName = 'Hero',
+  weaponKey = 'branch',
+  isTutorial = false,
+  weaponUpgrades: unknown = null,
+  enemyCount = 1,
+): { session: CombatSession; lootTables: LootTable[]; enemyName: string } {
   const weapon     = Weapon.from_file(join(__dirname, `../../database/weapons/${weaponKey}.yaml`));
   if (weaponUpgrades) applyWeaponCustomizations(weapon, weaponKey, weaponUpgrades);
   const fistsInfo = buildWeaponInfo(weapon);
@@ -309,10 +349,35 @@ function createSession(sessionId: string, enemyKey: EnemyKey | 'tutorial_swallow
   const playerState = new CombatantState(playerName, playerHp, weapon.resource_name, weapon.resource_max);
 
   const enemyFile = isTutorial ? 'tutorial_swallow' : enemyKey;
-  const { combatant: enemy, meta: enemyMeta, lootTable } = loadEnemy(
-    join(__dirname, `../../database/enemies/${enemyFile}.yaml`),
-    { id: 'enemy-1', teamId: 'team-b', pos: isTutorial ? { x: 5, y: 0 } : { x: 6, y: 2 }, movementRange: 2 },
-  );
+  const enemyPath = join(__dirname, `../../database/enemies/${enemyFile}.yaml`);
+
+  // Spawn N enemies. Names get an "A" / "B" suffix when more than one; ids
+  // follow the same letter for stability across log lines.
+  // Positions are spread vertically around the original enemy slot. Tutorial
+  // ignores enemyCount.
+  const effectiveCount = isTutorial ? 1 : Math.max(1, enemyCount);
+  const enemyStartPositions: Array<{ x: number; y: number }> = isTutorial
+    ? [{ x: 5, y: 0 }]
+    : effectiveCount === 1
+      ? [{ x: 6, y: 2 }]
+      : [{ x: 6, y: 1 }, { x: 6, y: 3 }];
+
+  const enemies: Array<{ combatant: Combatant; meta: CombatantMeta; lootTable: LootTable }> = [];
+  for (let i = 0; i < effectiveCount; i++) {
+    const suffix = effectiveCount > 1 ? String.fromCharCode(65 + i) : null; // A, B, C...
+    const id = effectiveCount > 1 ? `enemy-${suffix}` : 'enemy-1';
+    const loaded = loadEnemy(enemyPath, {
+      id,
+      teamId: 'team-b',
+      pos: enemyStartPositions[i],
+      movementRange: 2,
+    });
+    if (suffix !== null) {
+      loaded.combatant.name = `${loaded.combatant.name} ${suffix}`;
+      loaded.meta.state.name = loaded.combatant.name; // log lines use state.name
+    }
+    enemies.push(loaded);
+  }
 
   const boardConfig = isTutorial
     ? { width: 6, height: 2, obstacles: [] }
@@ -345,24 +410,28 @@ function createSession(sessionId: string, enemyKey: EnemyKey | 'tutorial_swallow
           teamId: 'team-a',
           weaponInfo: fistsInfo,
           weight: weapon.weight,
-          initiative: 0,      // set by assignInitiative in CombatSession constructor
-          initiativeRank: 0,  // set by assignInitiative in CombatSession constructor
+          initiative: 0,
+          initiativeRank: 0,
           sprite: playerSprite,
         }],
       },
       {
         id: 'team-b',
         name: 'Enemy',
-        combatants: [enemy],
+        combatants: enemies.map(e => e.combatant),
       },
     ],
   );
 
   session.meta.set('player-1', { weapon: weapon, state: playerState, pattern: [], patternIndex: 0 });
-  session.meta.set('enemy-1', enemyMeta);
+  for (const e of enemies) session.meta.set(e.combatant.id, e.meta);
   session.phase = 'intent';
   refreshTelegraphs(session);
-  return { session, lootTable, enemyName: enemy.name };
+  return {
+    session,
+    lootTables: enemies.map(e => e.lootTable),
+    enemyName: enemies[0].combatant.name.replace(/ [A-Z]$/, ''), // base name without suffix
+  };
 }
 
 // ---- Web server ----
@@ -689,7 +758,7 @@ app.get('/api/hunt', async (req: Request, res: Response) => {
     };
   }).sort((a, b) => a.enemy_health - b.enemy_health);
 
-  res.json({ baits, tutorial_complete: tutorialComplete });
+  res.json({ baits, tutorial_complete: tutorialComplete, is_dev: isDev(discordId) });
 });
 
 app.post('/api/hunt/start', async (req: Request, res: Response) => {
@@ -733,9 +802,18 @@ app.post('/api/hunt/start', async (req: Request, res: Response) => {
   const sessionId    = Math.random().toString(36).slice(2, 10);
   const equipped     = await equippedWeaponForCombat(char);
   const weaponKey    = equipped?.key ?? 'branch';
-  const { session: huntSession, lootTable, enemyName } = createSession(sessionId, enemyKey, playerSprite, char.name, weaponKey, false, equipped?.upgrades);
+  // Roll for a second enemy: 2.3% on real hunts, force-2 if the client passed
+  // it AND the user is a dev. Dev override exists so we can reliably test the
+  // multi-enemy code without waiting on a rare random spawn.
+  const wantsForceTwo = req.body?.count === 2;
+  const isDevUser     = isDev(discordId);
+  let enemyCount: number;
+  if (wantsForceTwo && isDevUser) enemyCount = 2;
+  else                            enemyCount = Math.random() < 0.023 ? 2 : 1;
+
+  const { session: huntSession, lootTables, enemyName } = createSession(sessionId, enemyKey, playerSprite, char.name, weaponKey, false, equipped?.upgrades, enemyCount);
   sessions.set(sessionId, huntSession);
-  sessionMeta.set(sessionId, { discordUserId: discordId, isTutorial: false, lootTable, enemyName, startedAt: new Date(), rounds: [] });
+  sessionMeta.set(sessionId, { discordUserId: discordId, isTutorial: false, lootTables, enemyName, startedAt: new Date(), rounds: [] });
 
   res.json({ session_url: `/battle/${sessionId}` });
 });
@@ -2336,7 +2414,10 @@ io.on('connection', (socket: Socket) => {
         let rewardSummary = 'No drops.';
         let korelEarned = 0;
         if (char) {
-          const rewards = await new RewardService().grant(meta.discordUserId, char.id, meta.lootTable, meta.enemyName).catch(() => null);
+          // One grant per defeated enemy — each enemy's loot table rolls
+          // independently. Sum up the results into a single rewards object so
+          // the existing summary/reply logic still works.
+          const rewards = await grantAllLoot(meta.discordUserId, char.id, meta.lootTables, meta.enemyName).catch(() => null);
           rewardSummary = rewards?.summary ?? 'No drops.';
           korelEarned = rewards?.currency ?? 0;
           const winLog = await prisma.battleLog.create({ data: {
@@ -2452,10 +2533,10 @@ io.on('connection', (socket: Socket) => {
       }
     }
 
-    const { session: fresh, lootTable, enemyName } = createSession(sessionId, enemyKey, playerSprite, playerName, playerWeaponKey, oldMeta?.isTutorial ?? false, playerUpgrades);
+    const { session: fresh, lootTables, enemyName } = createSession(sessionId, enemyKey, playerSprite, playerName, playerWeaponKey, oldMeta?.isTutorial ?? false, playerUpgrades);
     sessions.set(sessionId, fresh);
     if (oldMeta) {
-      sessionMeta.set(sessionId, { ...oldMeta, lootTable, enemyName, startedAt: new Date(), rounds: [] });
+      sessionMeta.set(sessionId, { ...oldMeta, lootTables, enemyName, startedAt: new Date(), rounds: [] });
     }
     io.to(sessionId).emit('session_joined', { playerTeamId: 'team-a', isTutorial: oldMeta?.isTutorial ?? false });
     io.to(sessionId).emit('session_state', fresh.toState());
@@ -2687,9 +2768,9 @@ async function bootstrapNewCharacter(
   await charRepo.create(discordId, input.name, 'branch', input.spriteKey, input.nationality, input.bio);
   const playerSprite = `${HOST}/sprites/${input.spriteKey}.png`;
   const sessionId = Math.random().toString(36).slice(2, 10);
-  const { session: charSession, lootTable, enemyName } = createSession(sessionId, 'lithkem_swallow', playerSprite, 'Hero', 'branch', true);
+  const { session: charSession, lootTables, enemyName } = createSession(sessionId, 'lithkem_swallow', playerSprite, 'Hero', 'branch', true);
   sessions.set(sessionId, charSession);
-  sessionMeta.set(sessionId, { discordUserId: discordId, isTutorial: true, lootTable, enemyName, startedAt: new Date(), rounds: [] });
+  sessionMeta.set(sessionId, { discordUserId: discordId, isTutorial: true, lootTables, enemyName, startedAt: new Date(), rounds: [] });
   return { ok: true, sessionUrl: `/battle/${sessionId}` };
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -344,6 +344,9 @@ function createSession(sessionId: string, enemyKey: EnemyKey | 'tutorial_swallow
           isAI: false,
           teamId: 'team-a',
           weaponInfo: fistsInfo,
+          weight: weapon.weight,
+          initiative: 0,      // set by assignInitiative in CombatSession constructor
+          initiativeRank: 0,  // set by assignInitiative in CombatSession constructor
           sprite: playerSprite,
         }],
       },

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -567,6 +567,27 @@ app.get('/api/info/enemies', (_req: Request, res: Response) => {
   res.json({ enemies });
 });
 
+// Lore — parses world_player.md by H1 headers into top-level sections.
+// Each section's body keeps its raw markdown; the client renders it.
+app.get('/api/info/lore', (_req: Request, res: Response) => {
+  const path = join(__dirname, '../../database/lore/world_player.md');
+  if (!fs.existsSync(path)) { res.json({ sections: [] }); return; }
+  const raw = fs.readFileSync(path, 'utf-8');
+  const sections: Array<{ title: string; body: string }> = [];
+  let current: { title: string; body: string } | null = null;
+  for (const line of raw.split(/\r?\n/)) {
+    const h1 = line.match(/^# (.+)$/);
+    if (h1) {
+      if (current) sections.push(current);
+      current = { title: h1[1].trim(), body: '' };
+      continue;
+    }
+    if (current) current.body += line + '\n';
+  }
+  if (current) sections.push(current);
+  res.json({ sections: sections.map(s => ({ title: s.title, body: s.body.trim() })) });
+});
+
 // ---- Hunt ----
 
 function loadEnemySummary(enemyKey: EnemyKey): { name: string; health: number; drops: Array<{ item_id: string; name: string; type: string; field: number[] }> } | null {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -278,27 +278,118 @@ function pathExists(width: number, height: number, blocked: Set<string>, start: 
   return false;
 }
 
-function randomHuntObstacles(): { pos: { x: number; y: number }; state: 'intact' }[] {
-  const W = 7, H = 5;
-  const PLAYER = { x: 0, y: 2 }, ENEMY = { x: 6, y: 2 };
-  for (let attempt = 0; attempt < 20; attempt++) {
-    const candidates: { x: number; y: number }[] = [];
-    for (let x = 1; x <= 5; x++) {
-      for (let y = 0; y <= 4; y++) candidates.push({ x, y });
+// Board geometry for hunt battles. Bigger than the tutorial so multi-enemy
+// combat has room to maneuver and ranged actions feel meaningful.
+const HUNT_BOARD_W = 16;
+const HUNT_BOARD_H = 12;
+const PLAYER_SPAWN_BOX = 5;            // player picks a random tile in (0..4, 0..4)
+const ENEMY_DIST_MIN  = 6;             // min chebyshev distance from player spawn
+const ENEMY_DIST_MAX  = 10;            // max chebyshev distance from player spawn
+const ENEMY_PAIR_MIN_SEP = 3;          // min chebyshev distance between two enemies
+const OBSTACLE_BUFFER = 1;             // tiles around each spawn tile that obstacles avoid
+                                       // (1 = 3x3 area centered on each spawn tile)
+const OBSTACLE_COUNT_MIN = 5;
+const OBSTACLE_COUNT_MAX = 15;
+
+type Pos = { x: number; y: number };
+
+function chebyshev(a: Pos, b: Pos): number {
+  return Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
+}
+
+// Random player spawn in a top-left 5x5 box.
+function randomPlayerSpawn(): Pos {
+  return {
+    x: Math.floor(Math.random() * PLAYER_SPAWN_BOX),
+    y: Math.floor(Math.random() * PLAYER_SPAWN_BOX),
+  };
+}
+
+// Pick an enemy spawn at a random distance/direction from the player, kept
+// on-board and away from the player and any previously-placed enemy tiles.
+function randomEnemySpawn(player: Pos, taken: Pos[]): Pos | null {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const dist = ENEMY_DIST_MIN + Math.floor(Math.random() * (ENEMY_DIST_MAX - ENEMY_DIST_MIN + 1));
+    const angle = Math.random() * Math.PI * 2;
+    const x = Math.round(player.x + Math.cos(angle) * dist);
+    const y = Math.round(player.y + Math.sin(angle) * dist);
+    if (x < 0 || x >= HUNT_BOARD_W || y < 0 || y >= HUNT_BOARD_H) continue;
+    const pos = { x, y };
+    if (chebyshev(pos, player) < ENEMY_DIST_MIN) continue;
+    if (taken.some(t => chebyshev(t, pos) < ENEMY_PAIR_MIN_SEP)) continue;
+    return pos;
+  }
+  return null;
+}
+
+// Build the full board layout for a hunt: player spawn, enemy spawn(s),
+// and obstacles. Obstacles avoid a 3x3 area around each spawn tile and
+// the layout is BFS-verified so every enemy is reachable from the player.
+function randomHuntBoard(enemyCount: number): {
+  playerSpawn: Pos;
+  enemySpawns: Pos[];
+  obstacles: { pos: Pos; state: 'intact' }[];
+} {
+  for (let layoutAttempt = 0; layoutAttempt < 20; layoutAttempt++) {
+    const playerSpawn = randomPlayerSpawn();
+
+    const enemySpawns: Pos[] = [];
+    let spawnFailed = false;
+    for (let i = 0; i < enemyCount; i++) {
+      const e = randomEnemySpawn(playerSpawn, enemySpawns);
+      if (!e) { spawnFailed = true; break; }
+      enemySpawns.push(e);
     }
+    if (spawnFailed) continue;
+
+    // Tiles to keep free of obstacles: the spawn tiles themselves plus a
+    // 3x3 buffer around each.
+    const noObstacle = new Set<string>();
+    const allSpawns = [playerSpawn, ...enemySpawns];
+    for (const s of allSpawns) {
+      for (let dx = -OBSTACLE_BUFFER; dx <= OBSTACLE_BUFFER; dx++) {
+        for (let dy = -OBSTACLE_BUFFER; dy <= OBSTACLE_BUFFER; dy++) {
+          noObstacle.add(`${s.x + dx},${s.y + dy}`);
+        }
+      }
+    }
+
+    const candidates: Pos[] = [];
+    for (let x = 0; x < HUNT_BOARD_W; x++) {
+      for (let y = 0; y < HUNT_BOARD_H; y++) {
+        if (!noObstacle.has(`${x},${y}`)) candidates.push({ x, y });
+      }
+    }
+    // Shuffle so we pick a random subset.
     for (let i = candidates.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [candidates[i], candidates[j]] = [candidates[j], candidates[i]];
     }
-    const count = 2 + Math.floor(Math.random() * 5); // inclusive 2..6
+    const count = OBSTACLE_COUNT_MIN + Math.floor(Math.random() * (OBSTACLE_COUNT_MAX - OBSTACLE_COUNT_MIN + 1));
     const picked = candidates.slice(0, count);
     const blocked = new Set(picked.map(p => `${p.x},${p.y}`));
-    if (pathExists(W, H, blocked, PLAYER, ENEMY)) {
-      return picked.map(pos => ({ pos, state: 'intact' as const }));
-    }
+
+    // Verify the player can reach every enemy without being walled off.
+    const allReachable = enemySpawns.every(e =>
+      pathExists(HUNT_BOARD_W, HUNT_BOARD_H, blocked, playerSpawn, e)
+    );
+    if (!allReachable) continue;
+
+    return {
+      playerSpawn,
+      enemySpawns,
+      obstacles: picked.map(pos => ({ pos, state: 'intact' as const })),
+    };
   }
-  // Extremely unlikely fallback — empty board rather than a stuck session.
-  return [];
+
+  // Fallback: empty obstacles, deterministic spawns. Should be extremely rare.
+  return {
+    playerSpawn: { x: 0, y: 0 },
+    enemySpawns: enemyCount > 1
+      ? [{ x: HUNT_BOARD_W - 1, y: 1 }, { x: HUNT_BOARD_W - 1, y: HUNT_BOARD_H - 1 }]
+      : [{ x: HUNT_BOARD_W - 1, y: HUNT_BOARD_H - 1 }],
+    obstacles: [],
+  };
 }
 
 // Runs RewardService.grant once per defeated enemy (one entry in lootTables
@@ -350,17 +441,17 @@ function createSession(
 
   const enemyFile = isTutorial ? 'tutorial_swallow' : enemyKey;
   const enemyPath = join(__dirname, `../../database/enemies/${enemyFile}.yaml`);
-
-  // Spawn N enemies. Names get an "A" / "B" suffix when more than one; ids
-  // follow the same letter for stability across log lines.
-  // Positions are spread vertically around the original enemy slot. Tutorial
-  // ignores enemyCount.
   const effectiveCount = isTutorial ? 1 : Math.max(1, enemyCount);
-  const enemyStartPositions: Array<{ x: number; y: number }> = isTutorial
-    ? [{ x: 5, y: 0 }]
-    : effectiveCount === 1
-      ? [{ x: 6, y: 2 }]
-      : [{ x: 6, y: 1 }, { x: 6, y: 3 }];
+
+  // Compute the full hunt layout (player spawn, enemy spawns, obstacles).
+  // Tutorial keeps its fixed mini-board.
+  const layout = isTutorial
+    ? {
+        playerSpawn: { x: 0, y: 1 },
+        enemySpawns: [{ x: 5, y: 0 }],
+        obstacles: [] as { pos: { x: number; y: number }; state: 'intact' }[],
+      }
+    : randomHuntBoard(effectiveCount);
 
   const enemies: Array<{ combatant: Combatant; meta: CombatantMeta; lootTable: LootTable }> = [];
   for (let i = 0; i < effectiveCount; i++) {
@@ -369,7 +460,7 @@ function createSession(
     const loaded = loadEnemy(enemyPath, {
       id,
       teamId: 'team-b',
-      pos: enemyStartPositions[i],
+      pos: layout.enemySpawns[i],
       movementRange: 2,
     });
     if (suffix !== null) {
@@ -382,12 +473,12 @@ function createSession(
   const boardConfig = isTutorial
     ? { width: 6, height: 2, obstacles: [] }
     : {
-        width: 7,
-        height: 5,
-        obstacles: randomHuntObstacles(),
+        width: HUNT_BOARD_W,
+        height: HUNT_BOARD_H,
+        obstacles: layout.obstacles,
       };
 
-  const playerStartPos = isTutorial ? { x: 0, y: 1 } : { x: 0, y: 2 };
+  const playerStartPos = layout.playerSpawn;
 
   const session = new CombatSession(
     sessionId,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -712,6 +712,10 @@ app.get('/api/info/reference', (_req: Request, res: Response) => {
   res.json({ sections: parseMarkdownSections(join(__dirname, '../../database/docs/reference.md')) });
 });
 
+app.get('/api/info/about', (_req: Request, res: Response) => {
+  res.json({ sections: parseMarkdownSections(join(__dirname, '../../database/docs/about.md')) });
+});
+
 // ---- Hunt ----
 
 function loadEnemySummary(enemyKey: EnemyKey): { name: string; health: number; drops: Array<{ item_id: string; name: string; type: string; field: number[] }> } | null {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -364,8 +364,53 @@ function createSession(sessionId: string, enemyKey: EnemyKey | 'tutorial_swallow
 
 // ---- Web server ----
 
+// Request log — one line per request to stdout, captured by PM2. Format:
+//   2026-06-04T17:30:01.123Z 1.2.3.4 GET /app/shop/general_store 200 12ms
+// Skipped paths: static assets (.js/.css/.png/etc) — they're high-volume and
+// usually not interesting for debugging. Failures on dynamic routes (4xx/5xx)
+// always log, including for skipped paths, so a missing CSS still shows up.
+app.use((req: Request, res: Response, next) => {
+  const start = Date.now();
+  const ip = (req.headers['cf-connecting-ip'] as string | undefined)
+    ?? (req.headers['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim()
+    ?? req.socket.remoteAddress
+    ?? '-';
+  const isAsset = /\.(?:js|css|png|jpg|jpeg|svg|ico|webp|woff2?|map)(?:\?|$)/.test(req.url);
+  res.on('finish', () => {
+    const dur = Date.now() - start;
+    if (!isAsset || res.statusCode >= 400) {
+      console.log(`[req] ${new Date().toISOString()} ${ip} ${req.method} ${req.url} ${res.statusCode} ${dur}ms`);
+    }
+  });
+  next();
+});
+
 app.use(express.static(join(__dirname, '../../public')));
 app.use(express.json());
+
+// Client-side error capture — SPA posts unhandled errors here; we log to
+// stdout (PM2 captures) so we can debug white screens / runtime crashes
+// without needing the user's devtools open. No auth required intentionally:
+// errors happen before auth in many cases, and the payload is rate-limit
+// guarded by Express's default body size cap.
+app.post('/api/client_error', (req: Request, res: Response) => {
+  const ip = (req.headers['cf-connecting-ip'] as string | undefined) ?? req.socket.remoteAddress ?? '-';
+  const ua = (req.headers['user-agent'] as string | undefined)?.slice(0, 200) ?? '-';
+  const body = req.body ?? {};
+  const summary = {
+    ts:      new Date().toISOString(),
+    ip,
+    ua,
+    url:     String(body.url ?? '').slice(0, 500),
+    message: String(body.message ?? '').slice(0, 500),
+    source:  String(body.source ?? '').slice(0, 200),
+    line:    body.line,
+    col:     body.col,
+    stack:   String(body.stack ?? '').slice(0, 2000),
+  };
+  console.log(`[client_error] ${JSON.stringify(summary)}`);
+  res.json({ ok: true });
+});
 
 // Read the bot version once at startup. Used to stamp asset URLs in HTML so
 // every deploy invalidates browser + Cloudflare caches without relying on a

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@ import {
   Client, GatewayIntentBits, Partials, Events,
   EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags,
   StringSelectMenuBuilder, StringSelectMenuOptionBuilder,
+  type Interaction,
   type GuildMember, type APIInteractionGuildMember,
 } from 'discord.js';
 import CharacterRepository from '../character/character_repository.js';
@@ -2778,14 +2779,16 @@ if (discordToken) {
       GatewayIntentBits.GuildMembers,
     ],
   });
-  // Each command registers its own InteractionCreate listener below — Node's
-  // default 10-listener cap fires a (misleading) "memory leak" warning at 11+.
-  // These are permanent listeners, not a growth leak, but the warning is real
-  // and pollutes logs. Bumping the cap suppresses it. Eventual cleanup: fold
-  // all command handlers into a single dispatcher (see 0.1.5 docs work).
-  discord.setMaxListeners(30);
+  // All Discord interactions fan out from ONE listener at the bottom of this
+  // block. Each command/button registers a handler into interactionHandlers
+  // instead of adding its own client.on() — the old pattern leaked ~17
+  // listeners against Node's default 10-listener cap and fired a misleading
+  // "memory leak" warning on every restart. Each handler is responsible for
+  // its own filter (isChatInputCommand + commandName, isButton + customId,
+  // etc.) and returns early if no match.
+  const interactionHandlers: Array<(interaction: Interaction) => Promise<void>> = [];
 
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     // ---- Hunt ----
 
     if (interaction.isChatInputCommand() && interaction.commandName === 'hunt') {
@@ -2837,7 +2840,7 @@ if (discordToken) {
 
   // ---- Admin commands ----
 
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'admin') return;
     if (!interaction.member || !isAdmin(interaction.member)) {
       await interaction.reply({ content: 'Unauthorized.', flags: MessageFlags.Ephemeral });
@@ -2948,7 +2951,7 @@ if (discordToken) {
 
   // ---- Dev commands ----
 
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'dev') return;
     if (!isDev(interaction.user.id)) {
       await interaction.reply({ content: 'Unauthorized.', flags: MessageFlags.Ephemeral });
@@ -2984,7 +2987,7 @@ if (discordToken) {
 
   // ---- Profile ----
 
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'profile') return;
 
     const chars = await charRepo.list(interaction.user.id);
@@ -3051,7 +3054,7 @@ if (discordToken) {
 
   // ---- Weapon equip ----
 
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'weapon') return;
 
     const chars = await charRepo.list(interaction.user.id);
@@ -3103,7 +3106,7 @@ if (discordToken) {
     await interaction.reply({ content: note, components: [row], flags: MessageFlags.Ephemeral });
   });
 
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     if (!interaction.isStringSelectMenu() || interaction.customId !== 'WeaponEquip') return;
 
     const chars = await charRepo.list(interaction.user.id);
@@ -3135,7 +3138,7 @@ if (discordToken) {
     [worldConfig.channels.enchanting_shop]: 'enchanting_shop',
   };
 
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'shop') return;
 
     const shopKey = CHANNEL_TO_SHOP[interaction.channelId];
@@ -3166,7 +3169,7 @@ if (discordToken) {
 
   // ---- Craft ----
 
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'craft') return;
 
     const chars = await charRepo.list(interaction.user.id);
@@ -3190,7 +3193,7 @@ if (discordToken) {
 
   // ---- Trade ----
 
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'trade') return;
 
     const target = interaction.options.getUser('user', true);
@@ -3223,7 +3226,7 @@ if (discordToken) {
 
   // ---- Weapons reference ----
 
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'weapon-stats') return;
     await interaction.reply({ content: `${HOST}/app/weapon-stats`, flags: MessageFlags.Ephemeral });
   });
@@ -3243,7 +3246,7 @@ if (discordToken) {
   // a lookup map instead of one listener per command (was the worst offender
   // for the MaxListeners warning).
   const appPageByCommand = new Map(APP_PAGE_LINKS.map(p => [p.command, p.path]));
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     if (!interaction.isChatInputCommand()) return;
     const path = appPageByCommand.get(interaction.commandName);
     if (path === undefined) return;
@@ -3256,9 +3259,20 @@ if (discordToken) {
 
   // ---- Ping ----
 
-  discord.on(Events.InteractionCreate, async (interaction) => {
+  interactionHandlers.push(async (interaction) => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'ping') return;
     await interaction.reply('Pong!');
+  });
+
+  // Single dispatcher — fans every interaction out to the handlers above.
+  // Each handler's filter ignores interactions it doesn't own, so iteration
+  // is effectively a routing table walk. Errors in one handler don't break
+  // siblings.
+  discord.on(Events.InteractionCreate, async (interaction) => {
+    for (const handler of interactionHandlers) {
+      try { await handler(interaction); }
+      catch (err) { console.error('interaction handler error:', err); }
+    }
   });
 
   // ---- Guild member join ----

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -612,12 +612,11 @@ app.get('/api/info/enemies', (_req: Request, res: Response) => {
   res.json({ enemies });
 });
 
-// Lore — parses world_player.md by H1 headers into top-level sections.
-// Each section's body keeps its raw markdown; the client renders it.
-app.get('/api/info/lore', (_req: Request, res: Response) => {
-  const path = join(__dirname, '../../database/lore/world_player.md');
-  if (!fs.existsSync(path)) { res.json({ sections: [] }); return; }
-  const raw = fs.readFileSync(path, 'utf-8');
+// Parses a markdown doc by H1 headers into top-level sections. Used by
+// the Lore + Reference info pages.
+function parseMarkdownSections(absPath: string): Array<{ title: string; body: string }> {
+  if (!fs.existsSync(absPath)) return [];
+  const raw = fs.readFileSync(absPath, 'utf-8');
   const sections: Array<{ title: string; body: string }> = [];
   let current: { title: string; body: string } | null = null;
   for (const line of raw.split(/\r?\n/)) {
@@ -630,7 +629,15 @@ app.get('/api/info/lore', (_req: Request, res: Response) => {
     if (current) current.body += line + '\n';
   }
   if (current) sections.push(current);
-  res.json({ sections: sections.map(s => ({ title: s.title, body: s.body.trim() })) });
+  return sections.map(s => ({ title: s.title, body: s.body.trim() }));
+}
+
+app.get('/api/info/lore', (_req: Request, res: Response) => {
+  res.json({ sections: parseMarkdownSections(join(__dirname, '../../database/lore/world_player.md')) });
+});
+
+app.get('/api/info/reference', (_req: Request, res: Response) => {
+  res.json({ sections: parseMarkdownSections(join(__dirname, '../../database/docs/reference.md')) });
 });
 
 // ---- Hunt ----

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -288,8 +288,26 @@ const ENEMY_DIST_MAX  = 10;            // max chebyshev distance from player spa
 const ENEMY_PAIR_MIN_SEP = 3;          // min chebyshev distance between two enemies
 const OBSTACLE_BUFFER = 1;             // tiles around each spawn tile that obstacles avoid
                                        // (1 = 3x3 area centered on each spawn tile)
-const OBSTACLE_COUNT_MIN = 5;
-const OBSTACLE_COUNT_MAX = 15;
+// Obstacle count is sampled from a normal distribution centered on the mean,
+// clamped to [MIN, MAX]. Bell shape favors ~10 obstacles, with the long tails
+// occasionally giving very sparse or very crowded boards.
+const OBSTACLE_COUNT_MEAN = 10;
+const OBSTACLE_COUNT_STDDEV = 4;
+const OBSTACLE_COUNT_MIN = 3;
+const OBSTACLE_COUNT_MAX = 25;
+
+function randomNormal(mean: number, stdDev: number): number {
+  // Box-Muller; clamp u1 away from 0 so log doesn't blow up.
+  const u1 = Math.random() || 1e-10;
+  const u2 = Math.random();
+  const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+  return mean + stdDev * z;
+}
+
+function rollObstacleCount(): number {
+  const n = Math.round(randomNormal(OBSTACLE_COUNT_MEAN, OBSTACLE_COUNT_STDDEV));
+  return Math.max(OBSTACLE_COUNT_MIN, Math.min(OBSTACLE_COUNT_MAX, n));
+}
 
 type Pos = { x: number; y: number };
 
@@ -365,7 +383,7 @@ function randomHuntBoard(enemyCount: number): {
       const j = Math.floor(Math.random() * (i + 1));
       [candidates[i], candidates[j]] = [candidates[j], candidates[i]];
     }
-    const count = OBSTACLE_COUNT_MIN + Math.floor(Math.random() * (OBSTACLE_COUNT_MAX - OBSTACLE_COUNT_MIN + 1));
+    const count = rollObstacleCount();
     const picked = candidates.slice(0, count);
     const blocked = new Set(picked.map(p => `${p.x},${p.y}`));
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2540,6 +2540,13 @@ httpServer.listen(PORT, () => {
 // has elapsed. Same maybeTickDaily logic — just driven by setInterval
 // instead of pageload. Lets stock drift (restock + destock-at-75%) feel
 // like the world exists between visits.
+//
+// IMPORTANT: SHOP_DIR is declared further down (with the other shop/recipe
+// path constants). The initial kick + setInterval registration happen here
+// at module load, but they reference SHOP_DIR through the runShopTick
+// closure — so we have to defer the first invocation until after SHOP_DIR
+// is bound. Calling `void runShopTick()` synchronously here would hit a
+// TDZ error ("Cannot access 'SHOP_DIR' before initialization").
 const SHOP_TICK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour — granularity for the 24h gate
 async function runShopTick(): Promise<void> {
   try {
@@ -2547,7 +2554,7 @@ async function runShopTick(): Promise<void> {
     if (n > 0) console.log(`[shop tick] ticked ${n} item(s)`);
   } catch (err) { console.error('[shop tick] failed', err); }
 }
-void runShopTick();
+setImmediate(() => { void runShopTick(); });
 setInterval(runShopTick, SHOP_TICK_INTERVAL_MS);
 
 // ---- Discord bot ----

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -280,11 +280,13 @@ function pathExists(width: number, height: number, blocked: Set<string>, start: 
 
 // Board geometry for hunt battles. Bigger than the tutorial so multi-enemy
 // combat has room to maneuver and ranged actions feel meaningful.
-const HUNT_BOARD_W = 16;
-const HUNT_BOARD_H = 12;
+const HUNT_BOARD_W = 12;
+const HUNT_BOARD_H = 10;
 const PLAYER_SPAWN_BOX = 5;            // player picks a random tile in (0..4, 0..4)
 const ENEMY_DIST_MIN  = 6;             // min chebyshev distance from player spawn
-const ENEMY_DIST_MAX  = 10;            // max chebyshev distance from player spawn
+const ENEMY_DIST_MAX  = 8;             // max chebyshev distance from player spawn (capped
+                                       // by board geometry — worst-case player spawn at
+                                       // (4,4) can only reach chebyshev 7 on a 12x10 board)
 const ENEMY_PAIR_MIN_SEP = 3;          // min chebyshev distance between two enemies
 const OBSTACLE_BUFFER = 1;             // tiles around each spawn tile that obstacles avoid
                                        // (1 = 3x3 area centered on each spawn tile)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -813,7 +813,12 @@ app.post('/api/hunt/start', async (req: Request, res: Response) => {
 
   const { session: huntSession, lootTables, enemyName } = createSession(sessionId, enemyKey, playerSprite, char.name, weaponKey, false, equipped?.upgrades, enemyCount);
   sessions.set(sessionId, huntSession);
-  sessionMeta.set(sessionId, { discordUserId: discordId, isTutorial: false, lootTables, enemyName, startedAt: new Date(), rounds: [] });
+  // Persist initiative rolls as a synthetic round 0 so the battle log table
+  // captures them alongside the per-turn rounds.
+  const rounds: { turn: number; log: string[] }[] = huntSession.initiativeLog.length > 0
+    ? [{ turn: 0, log: huntSession.initiativeLog }]
+    : [];
+  sessionMeta.set(sessionId, { discordUserId: discordId, isTutorial: false, lootTables, enemyName, startedAt: new Date(), rounds });
 
   res.json({ session_url: `/battle/${sessionId}` });
 });
@@ -2313,6 +2318,11 @@ io.on('connection', (socket: Socket) => {
     const isTut = sessionMeta.get(sessionId)?.isTutorial ?? false;
     socket.emit('session_joined', { playerTeamId: 'team-a', isTutorial: isTut });
     socket.emit('session_state', session.toState());
+    // Initiative rolls happen at session creation. Replay them on every
+    // join so refreshers + late-joiners see them at the top of their log.
+    if (session.initiativeLog.length > 0) {
+      socket.emit('turn_result', { log: session.initiativeLog });
+    }
     if (isTut) {
       socket.emit('tutorial_aside', { text: 'The lithkem swallow nests near lakes and rivers.  It uses water as a tool and weapon and is able to spit a blast hard enough to cut wood.  Be careful on your approach.' });
       socket.emit('tutorial_aside', { text: 'Click your character first, then select a highlighted tile to move, or select the tile you are on to stay put.', isOOC: true });
@@ -2536,7 +2546,10 @@ io.on('connection', (socket: Socket) => {
     const { session: fresh, lootTables, enemyName } = createSession(sessionId, enemyKey, playerSprite, playerName, playerWeaponKey, oldMeta?.isTutorial ?? false, playerUpgrades);
     sessions.set(sessionId, fresh);
     if (oldMeta) {
-      sessionMeta.set(sessionId, { ...oldMeta, lootTables, enemyName, startedAt: new Date(), rounds: [] });
+      const freshRounds: { turn: number; log: string[] }[] = fresh.initiativeLog.length > 0
+        ? [{ turn: 0, log: fresh.initiativeLog }]
+        : [];
+      sessionMeta.set(sessionId, { ...oldMeta, lootTables, enemyName, startedAt: new Date(), rounds: freshRounds });
     }
     io.to(sessionId).emit('session_joined', { playerTeamId: 'team-a', isTutorial: oldMeta?.isTutorial ?? false });
     io.to(sessionId).emit('session_state', fresh.toState());
@@ -2770,7 +2783,10 @@ async function bootstrapNewCharacter(
   const sessionId = Math.random().toString(36).slice(2, 10);
   const { session: charSession, lootTables, enemyName } = createSession(sessionId, 'lithkem_swallow', playerSprite, 'Hero', 'branch', true);
   sessions.set(sessionId, charSession);
-  sessionMeta.set(sessionId, { discordUserId: discordId, isTutorial: true, lootTables, enemyName, startedAt: new Date(), rounds: [] });
+  const tutorialRounds: { turn: number; log: string[] }[] = charSession.initiativeLog.length > 0
+    ? [{ turn: 0, log: charSession.initiativeLog }]
+    : [];
+  sessionMeta.set(sessionId, { discordUserId: discordId, isTutorial: true, lootTables, enemyName, startedAt: new Date(), rounds: tutorialRounds });
   return { ok: true, sessionUrl: `/battle/${sessionId}` };
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2778,6 +2778,12 @@ if (discordToken) {
       GatewayIntentBits.GuildMembers,
     ],
   });
+  // Each command registers its own InteractionCreate listener below — Node's
+  // default 10-listener cap fires a (misleading) "memory leak" warning at 11+.
+  // These are permanent listeners, not a growth leak, but the warning is real
+  // and pollutes logs. Bumping the cap suppresses it. Eventual cleanup: fold
+  // all command handlers into a single dispatcher (see 0.1.5 docs work).
+  discord.setMaxListeners(30);
 
   discord.on(Events.InteractionCreate, async (interaction) => {
     // ---- Hunt ----
@@ -3233,16 +3239,20 @@ if (discordToken) {
     { command: 'enemies',     path: '/enemies'     },
   ];
 
-  for (const { command, path } of APP_PAGE_LINKS) {
-    discord.on(Events.InteractionCreate, async (interaction) => {
-      if (!interaction.isChatInputCommand() || interaction.commandName !== command) return;
-      const token = getOrCreateToken(interaction.user.id);
-      await interaction.reply({
-        content: `${HOST}/app${path}?auth=${token}`,
-        flags: MessageFlags.Ephemeral,
-      });
+  // All 6 page-link commands share the same handler body — one listener with
+  // a lookup map instead of one listener per command (was the worst offender
+  // for the MaxListeners warning).
+  const appPageByCommand = new Map(APP_PAGE_LINKS.map(p => [p.command, p.path]));
+  discord.on(Events.InteractionCreate, async (interaction) => {
+    if (!interaction.isChatInputCommand()) return;
+    const path = appPageByCommand.get(interaction.commandName);
+    if (path === undefined) return;
+    const token = getOrCreateToken(interaction.user.id);
+    await interaction.reply({
+      content: `${HOST}/app${path}?auth=${token}`,
+      flags: MessageFlags.Ephemeral,
     });
-  }
+  });
 
   // ---- Ping ----
 

--- a/src/weapon/weapon.ts
+++ b/src/weapon/weapon.ts
@@ -80,6 +80,7 @@ export default class Weapon {
     name: string
     description: string
     hp: number
+    weight: number
     resource_name: string
     resource_max: number
     defend: Array<Action>
@@ -89,10 +90,11 @@ export default class Weapon {
     special: Array<Action>
     special_crit: Array<Action>
 
-    constructor(name: string, description: string, hp: number, resource_name: string, resource_max: number, defend: Array<Action>, defend_crit: Array<Action>, attack: Array<Action>, attack_crit: Array<Action>, special: Array<Action>, special_crit: Array<Action>) {
+    constructor(name: string, description: string, hp: number, weight: number, resource_name: string, resource_max: number, defend: Array<Action>, defend_crit: Array<Action>, attack: Array<Action>, attack_crit: Array<Action>, special: Array<Action>, special_crit: Array<Action>) {
         this.name = name;
         this.description = description;
         this.hp = hp;
+        this.weight = weight;
         this.resource_name = resource_name;
         this.resource_max = resource_max;
         this.defend = defend;
@@ -140,6 +142,7 @@ export default class Weapon {
             'Name': string,
             'Description': string,
             'HP'?: number,
+            'Weight'?: number,
             'Resource': { 'Name': string, 'Max': number },
             'Defend': [],
             'Defend Crit': [],
@@ -154,7 +157,8 @@ export default class Weapon {
         return new Weapon(
             weapon_data['Name'],
             weapon_data['Description'],
-            weapon_data['HP'] ?? 0,
+            weapon_data['HP']     ?? 0,
+            weapon_data['Weight'] ?? 0,
             weapon_data['Resource']['Name'],
             weapon_data['Resource']['Max'],
             weapon_data['Defend'].flatMap((action_object: ActionData) => from_json(action_object)),

--- a/webhook/index.js
+++ b/webhook/index.js
@@ -6,8 +6,23 @@ import { exec } from 'child_process';
 const SECRET = process.env.WEBHOOK_SECRET ?? '';
 const PORT = process.env.WEBHOOK_PORT ?? 9000;
 
+// All log lines go through here so they're consistently prefixed for
+// correlation with cloudflared journal / pm2 logs. PM2 also prefixes
+// each line with a timestamp when started with --time, but we include
+// our own ISO timestamp so log lines stay grep-friendly even if PM2
+// timestamps get stripped.
+function log(line) {
+    console.log(`[webhook] ${new Date().toISOString()} ${line}`);
+}
+
 createServer((req, res) => {
+    const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress || '-';
+    const ua = (req.headers['user-agent'] || '-').slice(0, 80);
+    const delivery = req.headers['x-github-delivery'] || '-';
+    log(`req ${req.method} ${req.url} ip=${ip} ua=${ua} delivery=${delivery}`);
+
     if (req.method !== 'POST' || req.url !== '/webhook') {
+        log(`-> 404 (method/url mismatch)`);
         res.writeHead(404);
         return res.end();
     }
@@ -18,32 +33,44 @@ createServer((req, res) => {
         const sig = req.headers['x-hub-signature-256'];
         const expected = 'sha256=' + createHmac('sha256', SECRET).update(body).digest('hex');
         if (sig !== expected) {
+            log(`-> 401 (bad signature)`);
             res.writeHead(401);
             return res.end('Unauthorized');
         }
 
         const event = req.headers['x-github-event'];
-        const payload = JSON.parse(body);
+        let payload;
+        try { payload = JSON.parse(body); }
+        catch (e) {
+            log(`-> 400 (bad JSON) error=${e.message}`);
+            res.writeHead(400);
+            return res.end('Bad payload');
+        }
 
         if (event === 'push' && payload.ref === 'refs/heads/dev') {
+            log(`-> 200 (deploy dev) sha=${(payload.after || '').slice(0,7)}`);
             res.writeHead(200);
             res.end('Deploying dev');
             exec('bash /home/mac-admin/Idya/deploy.sh', (err, stdout, stderr) => {
                 if (stdout) console.log('Deploy stdout:', stdout);
                 if (stderr) console.log('Deploy stderr:', stderr);
-                if (err) console.error('Deploy failed, exit code:', err.code);
+                if (err) log(`deploy dev failed exit=${err.code}`);
+                else     log(`deploy dev ok`);
             });
         } else if (event === 'push' && payload.ref === 'refs/heads/main') {
+            log(`-> 200 (deploy prod) sha=${(payload.after || '').slice(0,7)}`);
             res.writeHead(200);
             res.end('Deploying prod');
             exec('bash /home/mac-admin/Idya-prod/deploy-prod.sh', (err, stdout, stderr) => {
                 if (stdout) console.log('Deploy stdout:', stdout);
                 if (stderr) console.log('Deploy stderr:', stderr);
-                if (err) console.error('Deploy failed, exit code:', err.code);
+                if (err) log(`deploy prod failed exit=${err.code}`);
+                else     log(`deploy prod ok`);
             });
         } else {
+            log(`-> 200 (ignored) event=${event} ref=${payload.ref || '-'}`);
             res.writeHead(200);
             res.end('Ignored');
         }
     });
-}).listen(PORT, () => console.log(`Webhook listener on port ${PORT}`));
+}).listen(PORT, () => log(`listener on port ${PORT}`));


### PR DESCRIPTION
## Summary

0.1.5 release. 46 commits since the 0.1.4 merge. The big buckets:

### Combat — multi-combatant rewrite
- **Initiative system** (DnD-style: `1..100 − Weight`). Replaces all "player first" / "AI DOT first" / isAI move-priority hardcoded rules. Initiative ranks drive sub-phase order, DOT ticks, and contested-tile movement.
- **Weight stat** on every weapon + enemy. All `0` for now (per-weapon tuning is its own pass).
- **Multi-enemy spawn** — 2.3% chance of a 2-enemy spawn on bait consumption. Two enemies get `A`/`B` name suffixes; each rolls its own loot table; each starts at a random pattern index.
- **Dev `+2 (dev)` button** on each bait card (gated by `isDev(discordId)`) forces a 2-spawn for testing.
- **Re-route algorithm** changed — blocked combatants re-route toward original destination, not nearest enemy. Approximates "stop on the path".
- **Conflict log reworded** (`X yields to Y` → `X's path to (a,b) blocked by Y`).

### Combat — board redesign
- **12×10 hunt board** (was 7×5).
- **Random player spawn** in top-left 5×5 box.
- **Distance-based enemy spawn** — random chebyshev distance 6–8 at random angle; min separation 3 between two enemies.
- **Normal-distribution obstacles** (mean 10, stddev 4, clamped 3–25). 3×3 buffer around every spawn tile. BFS reachability verified.
- **Cell sizes tuned**: 72px → 48px desktop, 44px → 28px mobile.

### Info pages
- **Lore** (`/app/lore`) — curated player-facing world doc.
- **Reference** (`/app/reference`) — game terms reference + glossary with intra-page anchor links.
- **About** (`/app/about`) — single-section narrative.
- Markdown renderer gained tables, nested lists, numbered lists, code spans, anchor links.

### Crafting
- **Spellbook (Hiruos)** at EN level 2 and **Spellbook (Nodol)** at EN level 7 — parity with Quarterstaff and Dagger.

### Shop economy
- **Hourly destock loop** (was 24h-gated). Two clocks now — daily price/restock tick + hourly destock that fires when shelves hit 75% cap.
- **Stock_Max bumps** on 10 hot items.
- **SHOP_DIR TDZ fix** — shop tick was silently failing on prod since 0.1.3.
- **BigInt volume columns** — INT4 overflow was killing buy/sell on prod.

### Diagnostics
- **Express request logging** middleware.
- **`POST /api/client_error`** + `public/error-capture.js` for remote SPA error capture.
- **Webhook script** logs every delivery with method/URL/IP/UA/delivery-ID/outcome.

### Infrastructure
- **Discord listener consolidation** (12 separate listeners → 1 dispatcher).
- **Cloudflared tunnel consolidated to a single replica** with merged config. Was the actual root cause of intermittent 404s across 0.1.x.

Full detail in `docs/CHANGELOG.md` 0.1.5 section. Player-facing summary in `docs/CHANGELOG_DISCORD.md`.

## Test plan

- [ ] Auto-announce fires on prod after deploy with the Discord changelog rendered correctly
- [ ] Regular hunt → 1 enemy on a 12×10 board, initiative logs at top
- [ ] Dev +2 hunt → 2 enemies with `A`/`B` names, both must die, both drop loot
- [ ] Multi-enemy combat resolution: actions go in initiative order, conflict log says "X's path to (a,b) blocked by Y"
- [ ] Lore / Reference / About pages render in the Info sidebar
- [ ] Shop destock fires hourly (check logs on prod after deploy)
- [ ] Spellbook (Hiruos) and Spellbook (Nodol) are craftable at correct EN levels
- [ ] No `MaxListenersExceededWarning` on idya-prod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)